### PR TITLE
Prevent execution of delete playback if there are no entries

### DIFF
--- a/spec/large_hadron_migration_spec.rb
+++ b/spec/large_hadron_migration_spec.rb
@@ -342,6 +342,11 @@ describe "LargeHadronMigration", "replaying changes" do
     end
   end
 
+  it "doesn't replay delete if there are any" do
+    LargeHadronMigration.should_receive(:execute).never
+    LargeHadronMigration.replay_delete_changes("source", "source_changes")
+  end
+
 end
 
 describe "LargeHadronMigration", "units" do


### PR DESCRIPTION
Th PR avoids playing back the deletes if there are none which saves some extra time.
