### PR TITLE
Ruby 1.8 compatibility

### DIFF
--- a/lib/large-hadron-migrator.rb
+++ b/lib/large-hadron-migrator.rb
@@ -100,7 +100,12 @@ class LargeHadronMigrator < ActiveRecord::Migration
 
     raise "chunk_size must be >= 1" unless chunk_size >= 1
 
-    started = Time.now.strftime("%Y_%m_%d_%H_%M_%S_%3N")
+    started = if RUBY_VERSION < "1.9"
+      t = Time.now
+      t.strftime("%Y_%m_%d_%H_%M_%S") + '_' + (t.usec / 1000).to_s
+    else
+      Time.now.strftime("%Y_%m_%d_%H_%M_%S_%3N")
+    end
     new_table      = "lhmn_%s" % curr_table
     old_table      = "lhmo_%s_%s" % [started, curr_table]
     journal_table  = "lhmj_%s_%s" % [started, curr_table]


### PR DESCRIPTION
Hi,

My strange bug with bugged triggers deletes was due to bad table names. It is solved by emulating the `%3N` pattern in `Time#strftime` for Ruby < 1.9

I've accidentally included @colin's commit from @sofatutor's fork, but since it's also a Ruby 1.8 compatibility issue, I hope it doesn't matter.
