### PR TITLE
Make Lhm generally more mysql2-friendly

### DIFF
--- a/lib/lhm/sql_helper.rb
+++ b/lib/lhm/sql_helper.rb
@@ -28,7 +28,7 @@ module Lhm
       [statements].flatten.each do |statement|
         connection.execute(tagged(statement))
       end
-    rescue ActiveRecord::StatementInvalid, Mysql::Error => e
+    rescue => e
       error e.message
     end
 
@@ -36,7 +36,7 @@ module Lhm
       [statements].flatten.inject(0) do |memo, statement|
         memo += connection.update(tagged(statement))
       end
-    rescue ActiveRecord::StatementInvalid, Mysql::Error => e
+    rescue => e
       error e.message
     end
 

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -38,7 +38,11 @@ module Lhm
 
       def ddl
         sql = "show create table `#{ @table_name }`"
-        @connection.execute(sql).fetch_row.last
+        results = []
+        @connection.execute(sql).each(:as => :array) do |r|
+          results << r
+        end
+        results.first.last
       end
 
       def parse


### PR DESCRIPTION
This makes the error rescuing in SqlHelper more generic, and replaces the use of fetch_row(), in order to provide compatibility with the mysql2 gem.
