### PR TITLE
Fix missing newline at end of progress dots

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -91,6 +91,7 @@ module Lhm
 
         print "."
       end
+      print "\n"
     end
   end
 end


### PR DESCRIPTION
This keeps the begin migration/end migrations lines lined up nicely, rather than the end migration line being whacked at the end of the dots
