### PR TITLE
Make Table Timestamp Shorter

### DIFF
--- a/lib/lhm/migration.rb
+++ b/lib/lhm/migration.rb
@@ -22,7 +22,7 @@ module Lhm
     end
 
     def startstamp
-      (@start.to_f * 1000).round
+      @start.to_i
     end
   end
 end

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -21,6 +21,7 @@ describe Lhm::AtomicSwitcher do
 
     it "rename origin to archive" do
       switcher = Lhm::AtomicSwitcher.new(@migration, connection)
+      sleep 2
       switcher.run
 
       slave do
@@ -31,6 +32,7 @@ describe Lhm::AtomicSwitcher do
 
     it "rename destination to origin" do
       switcher = Lhm::AtomicSwitcher.new(@migration, connection)
+      sleep 2
       switcher.run
 
       slave do

--- a/spec/integration/locked_switcher_spec.rb
+++ b/spec/integration/locked_switcher_spec.rb
@@ -21,6 +21,7 @@ describe Lhm::LockedSwitcher do
 
     it "rename origin to archive" do
       switcher = Lhm::LockedSwitcher.new(@migration, connection)
+      sleep 2
       switcher.run
 
       slave do
@@ -31,6 +32,7 @@ describe Lhm::LockedSwitcher do
 
     it "rename destination to origin" do
       switcher = Lhm::LockedSwitcher.new(@migration, connection)
+      sleep 2
       switcher.run
 
       slave do

--- a/spec/unit/migration_spec.rb
+++ b/spec/unit/migration_spec.rb
@@ -17,7 +17,7 @@ describe Lhm::Migration do
   end
 
   it "should name archive" do
-    stamp = (@start.to_f * 1000).round
+    stamp = @start.to_i
     @migration.archive_name.must_equal "lhma_#{stamp}_origin"
   end
 end


### PR DESCRIPTION
This changes the way timestamp is created for temporary LHM tables. The old way is causing problems for long table names. Using short epoch now.
