### PR TITLE
Revert "Change to supports_atomic_switch? behavior: raise error instead ...

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -28,8 +28,7 @@ module Lhm
   #   Time to wait between chunks in milliseconds (defaults to: 100)
   # @option options [Boolean] :atomic_switch
   #   Use atomic switch to rename tables (defaults to: true)
-  #   If using a version of mysql affected by atomic switch bug, LHM forces user
-  #   to set this option (see SqlHelper#supports_atomic_switch?)
+  #   (see SqlHelper#supports_atomic_switch?)
   # @yield [Migrator] Yielded Migrator object records the changes
   # @return [Boolean] Returns true if the migration finishes
   # @raise [Error] Raises Lhm::Error in case of a error and aborts the migration

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -24,14 +24,9 @@ module Lhm
     end
 
     def run(options = {})
-      if !options.include?(:atomic_switch)
-        if supports_atomic_switch?
-          options[:atomic_switch] = true
-        else
-          raise Error.new(
-            "Using mysql #{version_string}. You must explicitly set " +
-            "options[:atomic_switch] (re SqlHelper#supports_atomic_switch?)")
-        end
+      unless options.include?(:atomic_switch)
+        options[:atomic_switch] = supports_atomic_switch?
+        atomic_switch_warning unless options[:atomic_switch]
       end
 
       migration = @migrator.run

--- a/lib/lhm/sql_helper.rb
+++ b/lib/lhm/sql_helper.rb
@@ -73,5 +73,16 @@ module Lhm
 
       keys.find {|k| k.to_s.downcase == key.to_s.downcase }
     end
+
+    def atomic_switch_warning
+      puts "\n********************************** WARNING **************************"
+      puts "* This version of mysql (#{version_string}) might not support atomic table"
+      puts "* renames while writing to binlogs [http://bugs.mysql.com/bug.php?id=39675]."
+      puts "* Defaulting to a nonatomic locking switch. You may cancel and force the"
+      puts "* atomic switch by restarting with options[:atomic_switch] => true"
+      puts "*********************************************************************\n"
+      puts "Continuing in... "
+      30.downto(1).each { |i| puts "#{i}... "; sleep 1 }
+    end
   end
 end

--- a/lib/lhm/version.rb
+++ b/lib/lhm/version.rb
@@ -2,5 +2,5 @@
 # Schmidt
 
 module Lhm
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
While it is a good idea to raise an error in cases the atomic switch bug
could happen, this forces users affected by it to port back this
change in all the migrations created using earlier versions of LHM.

This reverts commit d9893a3f3b5a7eb28d3f1aead4c75f68e9fa7b91. So users
still get a warning when trying to do it.

Conflicts:
    lib/lhm/invoker.rb
    lib/lhm/sql_helper.rb
