### PR TITLE
Add support for tables with outbound foreign key constraints.

### DIFF
--- a/lib/lhm/connection.rb
+++ b/lib/lhm/connection.rb
@@ -59,10 +59,7 @@ module Lhm
       end
 
       def destination_create(origin)
-        original    = %{CREATE TABLE "#{ origin.name }"}
-        replacement = %{CREATE TABLE "#{ origin.destination_name }"}
-
-        sql(origin.ddl.gsub(original, replacement))
+        sql(origin.destination_ddl)
       end
 
       def execute(sql)
@@ -125,10 +122,7 @@ module Lhm
       end
 
       def destination_create(origin)
-        original    = %{CREATE TABLE `#{ origin.name }`}
-        replacement = %{CREATE TABLE `#{ origin.destination_name }`}
-
-        sql(origin.ddl.gsub(original, replacement))
+        sql(origin.destination_ddl)
       end
 
       def execute(sql)

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -5,12 +5,13 @@ require 'lhm/sql_helper'
 
 module Lhm
   class Table
-    attr_reader :name, :columns, :indices, :pk, :ddl
+    attr_reader :name, :columns, :indices, :constraints, :pk, :ddl
 
     def initialize(name, pk = "id", ddl = nil)
       @name = name
       @columns = {}
       @indices = {}
+      @constraints = {}
       @pk = pk
       @ddl = ddl
     end
@@ -25,6 +26,27 @@ module Lhm
 
     def self.parse(table_name, connection)
       Parser.new(table_name, connection).parse
+    end
+
+    def destination_ddl
+      original    = %r{CREATE TABLE ("|`)#{ name }\1}
+      # Strange substitutions are happening when I put this in the string directly
+      repl = '\1'
+      replacement = %Q{CREATE TABLE #{repl}#{ destination_name }#{repl}}
+
+      dest = ddl
+      dest.gsub!(original, replacement)
+
+      foreign_keys = constraints.select {|col, c| !c[:referenced_column].nil?}
+
+      foreign_keys.keys.each_with_index do |key, i|
+        original = foreign_keys[key][:name]
+        # Offset the new key names by the total size so they cannot overlap
+        replacement = original.sub(/(_\d+)?$/, "_#{foreign_keys.size + i + 1}")
+        dest.gsub!(original, replacement)
+      end
+
+      dest
     end
 
     class Parser
@@ -59,6 +81,10 @@ module Lhm
           extract_indices(read_indices).each do |idx, columns|
             table.indices[idx] = columns
           end
+
+          extract_constraints(read_constraints).each do |data|
+            table.constraints[data[:column]] = data
+          end
         end
       end
 
@@ -91,6 +117,31 @@ module Lhm
             memo[idx] << column
             memo
           end
+      end
+
+      def read_constraints
+        @connection.select_all %Q{
+          select *
+            from information_schema.key_column_usage
+           where table_name = '#{ @table_name }'
+             and table_schema = '#{ @schema_name }'
+        }
+      end
+
+      def extract_constraints(constraints)
+        constraints.map do |row|
+          constraint_name = struct_key(row, 'CONSTRAINT_NAME')
+          column_name = struct_key(row, "COLUMN_NAME")
+          ref_table_name = struct_key(row, 'REFERENCED_TABLE_NAME')
+          ref_col_name = struct_key(row, 'REFERENCED_COLUMN_NAME')
+
+          {
+            :name              => row[constraint_name],
+            :column            => row[column_name],
+            :referenced_table  => row[ref_table_name],
+            :referenced_column => row[ref_col_name]
+          }
+        end
       end
 
       def extract_primary_key(schema)

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -96,7 +96,6 @@ module Lhm
               table.constraints[data[:column]] = data
             end
 
-            next if data[:name] == 'PRIMARY'
             constraints[data[:name]] = data
           end
 
@@ -140,6 +139,7 @@ module Lhm
           select *
             from information_schema.key_column_usage
            where table_schema = '#{ @schema_name }'
+             and referenced_column_name is not null
         }
         query += %Q{
              and table_name = '#{ @table_name }'

--- a/spec/fixtures/fk_example.ddl
+++ b/spec/fixtures/fk_example.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `fk_example` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_example_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/fk_example_non_sequential.ddl
+++ b/spec/fixtures/fk_example_non_sequential.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `fk_example_non_sequential` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_example_ibfk_2` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -36,11 +36,13 @@ describe Lhm do
       end
 
       slave do
-        table_read(:fk_example).constraints['user_id'].slice(:name, :referenced_table, :referenced_column).must_equal({
+        actual = table_read(:fk_example).constraints['user_id']
+        expected = {
           name: 'fk_example_ibfk_2',
           referenced_table: 'users',
           referenced_column: 'id'
-        })
+        }
+        hash_slice(actual, expected.keys).must_equal(expected)
       end
     end
   end
@@ -56,11 +58,13 @@ describe Lhm do
       end
 
       slave do
-        table_read(:fk_example_non_sequential).constraints['user_id'].slice(:name, :referenced_table, :referenced_column).must_equal({
+        actual = table_read(:fk_example_non_sequential).constraints['user_id']
+        expected = {
           name: 'fk_example_ibfk_1',
           referenced_table: 'users',
           referenced_column: 'id'
-        })
+        }
+        hash_slice(actual, expected.keys).must_equal(expected)
       end
     end
   end

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -34,6 +34,14 @@ describe Lhm do
       Lhm.change_table(:fk_example) do |t|
         t.add_column(:new_column, "INT(12) DEFAULT '0'")
       end
+
+      slave do
+        table_read(:fk_example).constraints['user_id'].slice(:name, :referenced_table, :referenced_column).must_equal({
+          name: 'fk_example_ibfk_2',
+          referenced_table: 'users',
+          referenced_column: 'id'
+        })
+      end
     end
   end
 
@@ -45,6 +53,14 @@ describe Lhm do
     it 'should be able to create this table' do
       Lhm.change_table(:fk_example_non_sequential) do |t|
         t.add_column(:new_column, "INT(12) DEFAULT '0'")
+      end
+
+      slave do
+        table_read(:fk_example_non_sequential).constraints['user_id'].slice(:name, :referenced_table, :referenced_column).must_equal({
+          name: 'fk_example_ibfk_1',
+          referenced_table: 'users',
+          referenced_column: 'id'
+        })
       end
     end
   end

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -11,20 +11,43 @@ describe Lhm do
   before(:each) { connect_master! }
 
   before(:each) do
-    # Be absolutely sure it is not there
-    execute 'drop table if exists fk_example'
+    # Be absolutely sure none of these exist yet
+    Lhm.cleanup(true)
+    %w{fk_example fk_example_non_sequential}.each do |table|
+      execute "drop table if exists #{table}"
+    end
+
     table_create(:users)
-    table_create(:fk_example)
   end
 
-  after(:each) do
-    # Clean it up since it could cause trouble
-    execute 'drop table if exists fk_example'
-  end
+  describe 'the simplest case' do
+    before(:each) do
+      table_create(:fk_example)
+    end
 
-  it 'should handle tables with foriegn keys' do
-    Lhm.change_table(:fk_example) do |t|
-      t.add_column(:new_column, "INT(12) DEFAULT '0'")
+    after (:each) do
+      # Clean it up since it could cause trouble
+      execute 'drop table if exists fk_example'
+      Lhm.cleanup(true)
+    end
+    it 'should handle tables with foriegn keys' do
+      Lhm.change_table(:fk_example) do |t|
+        t.add_column(:new_column, "INT(12) DEFAULT '0'")
+      end
     end
   end
+
+  describe 'the foreign key sequence number is not 1' do
+    before(:each) do
+      table_create(:fk_example_non_sequential)
+    end
+
+    it 'should be able to create this table' do
+      Lhm.change_table(:fk_example_non_sequential) do |t|
+        t.add_column(:new_column, "INT(12) DEFAULT '0'")
+      end
+    end
+  end
+
+
 end

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -1,0 +1,30 @@
+# Copyright (c) 2011 - 2013, SoundCloud Ltd., Rany Keddo, Tobias Bielohlawek, Tobias
+# Schmidt
+
+require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
+
+require 'lhm'
+
+describe Lhm do
+  include IntegrationHelper
+
+  before(:each) { connect_master! }
+
+  before(:each) do
+    # Be absolutely sure it is not there
+    execute 'drop table if exists fk_example'
+    table_create(:users)
+    table_create(:fk_example)
+  end
+
+  after(:each) do
+    # Clean it up since it could cause trouble
+    execute 'drop table if exists fk_example'
+  end
+
+  it 'should handle tables with foriegn keys' do
+    Lhm.change_table(:fk_example) do |t|
+      t.add_column(:new_column, "INT(12) DEFAULT '0'")
+    end
+  end
+end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -121,6 +121,16 @@ module IntegrationHelper
     connection.table_exists?(table.name)
   end
 
+
+  def hash_slice(hash, keys)
+    if hash.respond_to?(:slice)
+      hash.slice(*keys)
+    else
+      check = {}
+      keys.each {|k| check[k] = hash[k]}
+      check
+    end
+  end
   #
   # Database Helpers
   #

--- a/spec/integration/table_spec.rb
+++ b/spec/integration/table_spec.rb
@@ -49,13 +49,13 @@ describe Lhm::Table do
           @table = table_create(:fk_example)
           @table.constraints.keys.must_equal %w{user_id}
 
-          compare = {
+          expected = {
             name: "fk_example_ibfk_1",
             referenced_table: "users",
             referenced_column: "id"
           }
 
-          @table.constraints['user_id'].slice(*(compare.keys)).must_equal compare
+          hash_slice(@table.constraints['user_id'], expected.keys).must_equal expected
         ensure
           execute 'drop table if exists fk_example'
         end

--- a/spec/integration/table_spec.rb
+++ b/spec/integration/table_spec.rb
@@ -43,6 +43,23 @@ describe Lhm::Table do
           indices["index_users_on_reference"].
           must_equal(["reference"])
       end
+
+      it "should parse constraints" do
+        begin
+          @table = table_create(:fk_example)
+          @table.constraints.keys.must_equal %w{user_id}
+
+          compare = {
+            name: "fk_example_ibfk_1",
+            referenced_table: "users",
+            referenced_column: "id"
+          }
+
+          @table.constraints['user_id'].slice(*(compare.keys)).must_equal compare
+        ensure
+          execute 'drop table if exists fk_example'
+        end
+      end
     end
   end
 end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -15,19 +15,32 @@ describe Lhm::Table do
     end
   end
 
+  describe 'ddl' do
+    it "should build the destination table" do
+      table = "users"
+      schema = "default"
+
+      @table = Lhm::Table.new(table, schema, "id", %Q{CREATE TABLE `#{table}` (random_constraint)})
+      @table.constraints['user_id'] = {:name => 'random_constraint', :referenced_column => true}
+      Lhm::Table.schema_constraints(schema, {'random_constraint_1' => true})
+
+      @table.destination_ddl.must_equal %Q{CREATE TABLE `#{@table.destination_name}` (random_constraint_2)}
+    end
+  end
+
   describe "constraints" do
     it "should be satisfied with a single column primary key called id" do
-      @table = Lhm::Table.new("table", "id")
+      @table = Lhm::Table.new("table", "default", "id")
       @table.satisfies_primary_key?.must_equal true
     end
 
     it "should not be satisfied with a primary key unless called id" do
-      @table = Lhm::Table.new("table", "uuid")
+      @table = Lhm::Table.new("table", "default", "uuid")
       @table.satisfies_primary_key?.must_equal false
     end
 
     it "should not be satisfied with multicolumn primary key" do
-      @table = Lhm::Table.new("table", ["id", "secondary"])
+      @table = Lhm::Table.new("table", "default", ["id", "secondary"])
       @table.satisfies_primary_key?.must_equal false
     end
   end


### PR DESCRIPTION
This branch allows LHM to migrate tables with (outbound) foreign key constraints by renaming the constraints on the destination table. 

