### PR TITLE
fixing setup-cluster script for when there is multiple mysql_install_db

### DIFF
--- a/bin/lhm-spec-setup-cluster.sh
+++ b/bin/lhm-spec-setup-cluster.sh
@@ -13,7 +13,6 @@ source ~/.lhm
 # Main
 #
 
-install_bin="$(echo ./*/mysql_install_db)"
 
 mkdir -p "$basedir/master/data" "$basedir/slave/data"
 
@@ -61,7 +60,7 @@ CNF
 
 (
   cd "$mysqldir"
+  install_bin="$(echo ./*/mysql_install_db | tr " " "\\n" | head -1)"
   $install_bin --datadir="$basedir/master/data"
   $install_bin --datadir="$basedir/slave/data"
-
 )


### PR DESCRIPTION
When there is more the one `mysql_install_db` script on the mysql folder(which is my case, installation from homebrew) the setup-cluster script dont work as it cannot execute the right `mysql_install_db`.

This PR, will use the first `mysql_install_db` found.
