### PR TITLE
extract Throttle logic

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -17,7 +17,7 @@ module Lhm
       @migration = migration
       @connection = connection
       @stride = options[:stride] || 40_000
-      @throttle = options[:throttle] || 100
+      @throttle = options[:throttle]
       @start = options[:start] || select_start
       @limit = options[:limit] || select_limit
     end
@@ -57,10 +57,6 @@ module Lhm
       limit ? limit.to_i : nil
     end
 
-    def throttle_seconds
-      @throttle / 1000.0
-    end
-
   private
 
     def conditions
@@ -93,8 +89,8 @@ module Lhm
       up_to do |lowest, highest|
         affected_rows = @connection.update(copy(lowest, highest))
 
-        if affected_rows > 0
-          sleep(throttle_seconds)
+        if @throttle && affected_rows > 0
+          @throttle.run
         end
 
         print "."

--- a/lib/lhm/throttle.rb
+++ b/lib/lhm/throttle.rb
@@ -1,0 +1,42 @@
+require 'lhm/throttle/time'
+
+module Lhm
+  module Throttle
+    CLASSES = {:time_throttle => Throttle::Time}
+
+    def throttle
+      @throttle ||= Throttle::Time.new
+    end
+
+    def setup_throttle(type, options = {})
+      @throttle = Factory.create_throttle(type, options)
+    end
+
+    class Factory
+
+      def self.create_throttle(type, options = {})
+        case type
+        when Fixnum
+          # we still support the throttle as a Fixnum input
+          warn "throttle option will no loger accept a Fixnum in the next versions."
+          legacy_throttle(type)
+        when Lhm::Command
+          type
+        when Symbol
+          CLASSES[type].new(options)
+        when String
+          CLASSES[type.to_sym].new(options)
+        when Class
+          type.new(options)
+        else
+          raise ArgumentError, 'type argument must be a Symbol, String or Class'
+        end
+      end
+
+      def self.legacy_throttle(t)
+        Throttle::LegacyTime.new(t)
+      end
+    end
+
+  end
+end

--- a/lib/lhm/throttle/time.rb
+++ b/lib/lhm/throttle/time.rb
@@ -1,0 +1,26 @@
+module Lhm
+  module Throttle
+
+    class Time
+      include Command
+
+      attr_accessor :throttle_seconds
+
+      def initialize(options = {})
+        @throttle_seconds = options[:delay] || 0.1
+      end
+
+      def execute
+        sleep throttle_seconds
+      end
+    end
+
+    class LegacyTime < Time
+
+      def initialize(throttle)
+        @throttle_seconds = throttle / 1000.0
+      end
+    end
+
+  end
+end

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -102,10 +102,4 @@ describe Lhm::Chunker do
       end
     end
   end
-
-  describe "throttling" do
-    it "should default to 100 milliseconds" do
-      @chunker.throttle_seconds.must_equal 0.1
-    end
-  end
 end

--- a/spec/unit/throttle_spec.rb
+++ b/spec/unit/throttle_spec.rb
@@ -1,0 +1,90 @@
+require File.expand_path(File.dirname(__FILE__)) + '/unit_helper'
+
+require 'lhm/throttle'
+
+describe Lhm::Throttle do
+  include UnitHelper
+
+  before :each do
+    @mock = Class.new do
+      extend Lhm::Throttle
+    end
+  end
+
+  describe "#setup_throttle" do
+
+    describe "when passing 100 milliseconds" do
+
+      before do
+        @mock.setup_throttle(100)
+      end
+
+      it "instantiates a legacy throttle" do
+        @mock.throttle.class.must_equal Lhm::Throttle::LegacyTime
+      end
+
+      it "returns in seconds" do
+        @mock.throttle.throttle_seconds.must_equal 0.1
+      end
+    end
+
+    describe "when passing a key" do
+
+      before do
+        @mock.setup_throttle(:time_throttle, :delay => 2)
+      end
+
+      it "instantiates the time throttle" do
+        @mock.throttle.class.must_equal Lhm::Throttle::Time
+      end
+
+      it "returns 2 seconds as time" do
+        @mock.throttle.throttle_seconds.must_equal 2
+      end
+    end
+
+    describe "when passing an instance" do
+
+      before do
+        @instance = Class.new(Lhm::Throttle::Time) do
+          def throttle_seconds
+            0
+          end
+        end.new
+
+        @mock.setup_throttle(@instance)
+      end
+
+      it "returns the instace given" do
+        @mock.throttle.must_equal @instance
+      end
+
+      it "returns 0 seconds as time" do
+        @mock.throttle.throttle_seconds.must_equal 0
+      end
+    end
+
+    describe "when passing a class" do
+
+      before do
+        @klass = Class.new(Lhm::Throttle::Time)
+        @mock.setup_throttle(@klass)
+      end
+
+      it "has the same class as given" do
+        @mock.throttle.class.must_equal @klass
+      end
+    end
+  end
+
+  describe "#throttle" do
+
+    it "returns the default Time based" do
+      @mock.throttle.class.must_equal Lhm::Throttle::Time
+    end
+
+    it "should default to 100 milliseconds" do
+      @mock.throttle.throttle_seconds.must_equal 0.1
+    end
+  end
+end


### PR DESCRIPTION
Now we are able to given a special Throttle implementation, or use the Time one.

As explained on https://github.com/soundcloud/lhm/issues/23#issuecomment-20717297 we will be able to do this:

``` ruby
# common implementation
Lhm.setup_throttle(:time_throttle, connection: delay: 5 )
# custom.
Lhm.setup_throttle(Shopify::LhmThrottle, options )
Lhm.setup_throttle(SoundCloud::LhmThrottle, options )
if Rails.env.development?
  Lhm.setup_throttle(Lhm::Throttle::Null, options )
end
```
