### PR TITLE
Make the primary key to use for the migration configurable

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -34,6 +34,8 @@ module Lhm
   #   Use atomic switch to rename tables (defaults to: true)
   #   If using a version of mysql affected by atomic switch bug, LHM forces user
   #   to set this option (see SqlHelper#supports_atomic_switch?)
+  # @option options [String] :order_column
+  #   Column name to order records by. This column must be unique for every record (defaults to: "id")
   # @yield [Migrator] Yielded Migrator object records the changes
   # @return [Boolean] Returns true if the migration finishes
   # @raise [Error] Raises Lhm::Error in case of a error and aborts the migration

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -41,7 +41,7 @@ module Lhm
   # @raise [Error] Raises Lhm::Error in case of a error and aborts the migration
   def self.change_table(table_name, options = {}, &block)
     origin = Table.parse(table_name, connection)
-    invoker = Invoker.new(origin, connection)
+    invoker = Invoker.new(origin, connection, options)
     block.call(invoker.migrator)
     invoker.run(options)
     true

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -18,7 +18,6 @@ module Lhm
       @connection = connection
       @stride = options[:stride] || 40_000
       @throttle = options[:throttle] || 100
-      @order_column = options[:order_column] || @migration.origin.pk
       @start = options[:start] || select_start
       @limit = options[:limit] || select_limit
     end
@@ -45,16 +44,16 @@ module Lhm
     def copy(lowest, highest)
       "insert ignore into `#{ destination_name }` (#{ columns }) " +
       "select #{ select_columns } from `#{ origin_name }` " +
-      "#{ conditions } #{ origin_name }.`#{ @order_column }` between #{ lowest } and #{ highest }"
+      "#{ conditions } #{ origin_name }.`#{ @migration.order_column }` between #{ lowest } and #{ highest }"
     end
 
     def select_start
-      start = connection.select_value("select min(#{ @order_column }) from #{ origin_name }")
+      start = connection.select_value("select min(#{ @migration.order_column }) from #{ origin_name }")
       start ? start.to_i : nil
     end
 
     def select_limit
-      limit = connection.select_value("select max(#{ @order_column }) from #{ origin_name }")
+      limit = connection.select_value("select max(#{ @migration.order_column }) from #{ origin_name }")
       limit ? limit.to_i : nil
     end
 

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -18,6 +18,7 @@ module Lhm
       @connection = connection
       @stride = options[:stride] || 40_000
       @throttle = options[:throttle] || 100
+      @order_column = options[:order_column] || @migration.origin.pk
       @start = options[:start] || select_start
       @limit = options[:limit] || select_limit
     end
@@ -44,16 +45,16 @@ module Lhm
     def copy(lowest, highest)
       "insert ignore into `#{ destination_name }` (#{ columns }) " +
       "select #{ select_columns } from `#{ origin_name }` " +
-      "#{ conditions } #{ origin_name }.`id` between #{ lowest } and #{ highest }"
+      "#{ conditions } #{ origin_name }.`#{ @order_column }` between #{ lowest } and #{ highest }"
     end
 
     def select_start
-      start = connection.select_value("select min(id) from #{ origin_name }")
+      start = connection.select_value("select min(#{ @order_column }) from #{ origin_name }")
       start ? start.to_i : nil
     end
 
     def select_limit
-      limit = connection.select_value("select max(id) from #{ origin_name }")
+      limit = connection.select_value("select max(#{ @order_column }) from #{ origin_name }")
       limit ? limit.to_i : nil
     end
 

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -17,6 +17,7 @@ module Lhm
       @common = migration.intersection
       @origin = migration.origin
       @destination = migration.destination
+      @order_column = migration.order_column
       @connection = connection
     end
 
@@ -59,7 +60,7 @@ module Lhm
         create trigger `#{ trigger(:del) }`
         after delete on `#{ @origin.name }` for each row
         delete ignore from `#{ @destination.name }` #{ SqlHelper.annotation }
-        where `#{ @destination.name }`.`#{ @destination.pk }` = OLD.`#{ @origin.pk }`
+        where `#{ @destination.name }`.`#{ @order_column }` = OLD.`#{ @order_column }`
       }
     end
 

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -59,7 +59,7 @@ module Lhm
         create trigger `#{ trigger(:del) }`
         after delete on `#{ @origin.name }` for each row
         delete ignore from `#{ @destination.name }` #{ SqlHelper.annotation }
-        where `#{ @destination.name }`.`id` = OLD.`id`
+        where `#{ @destination.name }`.`#{ @destination.pk }` = OLD.`#{ @origin.pk }`
       }
     end
 

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -18,9 +18,9 @@ module Lhm
 
     attr_reader :migrator, :connection
 
-    def initialize(origin, connection)
+    def initialize(origin, connection, options)
       @connection = connection
-      @migrator = Migrator.new(origin, connection)
+      @migrator = Migrator.new(origin, connection, options)
     end
 
     def run(options = {})

--- a/lib/lhm/migration.rb
+++ b/lib/lhm/migration.rb
@@ -5,12 +5,13 @@ require 'lhm/intersection'
 
 module Lhm
   class Migration
-    attr_reader :origin, :destination, :conditions
+    attr_reader :origin, :destination, :conditions, :order_column
 
-    def initialize(origin, destination, conditions = nil, time = Time.now)
+    def initialize(origin, destination, order_column, conditions = nil, time = Time.now)
       @origin = origin
       @destination = destination
       @conditions = conditions
+      @order_column = order_column
       @start = time
     end
 

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -16,7 +16,7 @@ module Lhm
     end
 
     def satisfies_primary_key?
-      @pk == "id"
+      @pk.is_a?(String) && !!(@columns[@pk][:type] =~ /int\(\d+\)/)
     end
 
     def destination_name

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -16,7 +16,11 @@ module Lhm
     end
 
     def satisfies_primary_key?
-      @pk.is_a?(String) && !!(@columns[@pk][:type] =~ /int\(\d+\)/)
+      @pk.is_a?(String) && numeric_type?(@columns[@pk][:type])
+    end
+
+    def can_use_order_column?(column)
+      numeric_type?(@columns[column][:type])
     end
 
     def destination_name
@@ -104,8 +108,16 @@ module Lhm
           defn[column_name]
         end
 
-        keys.length == 1 ? keys.first : keys
+        case keys.length
+        when 0 then nil
+        when 1 then keys.first
+        else keys
+        end
       end
+    end
+
+    def numeric_type?(type)
+      !!(type.match(/int\(\d+\)|decimal|numeric|float|double|integer/))
     end
   end
 end

--- a/spec/fixtures/no_primary_key.ddl
+++ b/spec/fixtures/no_primary_key.ddl
@@ -1,0 +1,4 @@
+CREATE TABLE `no_primary_key` (
+  `foreign_id` int(11) NOT NULL,
+  `value` int(11) NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/primary_keys.ddl
+++ b/spec/fixtures/primary_keys.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `primary_keys` (
+  `weird_id` int(11) NOT NULL AUTO_INCREMENT,
+  `origin` int(11) DEFAULT NULL,
+  `common` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`weird_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -16,7 +16,7 @@ describe Lhm::AtomicSwitcher do
     before(:each) do
       @origin      = table_create("origin")
       @destination = table_create("destination")
-      @migration   = Lhm::Migration.new(@origin, @destination)
+      @migration   = Lhm::Migration.new(@origin, @destination, "id")
     end
 
     it "rename origin to archive" do

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -16,7 +16,7 @@ describe Lhm::Chunker do
     before(:each) do
       @origin = table_create(:origin)
       @destination = table_create(:destination)
-      @migration = Lhm::Migration.new(@origin, @destination)
+      @migration = Lhm::Migration.new(@origin, @destination, "id")
     end
 
     it "should copy 23 rows from origin to destination" do

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -16,7 +16,7 @@ describe Lhm::Entangler do
     before(:each) do
       @origin = table_create("origin")
       @destination = table_create("destination")
-      @migration = Lhm::Migration.new(@origin, @destination)
+      @migration = Lhm::Migration.new(@origin, @destination, "id")
       @entangler = Lhm::Entangler.new(@migration, connection)
     end
 

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -205,6 +205,22 @@ describe Lhm do
       end
     end
 
+    it "should change a table with a primary key other than id" do
+      table_create(:primary_keys)
+
+      Lhm.change_table(:primary_keys, :atomic_switch => false) do |t|
+        t.change_column(:weird_id, "int(5)")
+      end
+
+      slave do
+        table_read(:primary_keys).columns["weird_id"].must_equal({
+          :type => "int(5)",
+          :is_nullable => "NO",
+          :column_default => "0"
+        })
+      end
+    end
+
     describe "parallel" do
       it "should perserve inserts during migration" do
         50.times { |n| execute("insert into users set reference = '#{ n }'") }

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -221,6 +221,23 @@ describe Lhm do
       end
     end
 
+    it "should change a table with a no primary key" do
+      table_create(:no_primary_key)
+
+      Lhm.change_table(:no_primary_key, :atomic_switch => false, :order_column => 'foreign_id') do |t|
+        t.change_column(:value, "text")
+      end
+
+      slave do
+        table_read(:no_primary_key).columns["value"].must_equal({
+          :type => "text",
+          :is_nullable => "YES",
+          :column_default => nil
+        })
+      end
+    end
+
+
     describe "parallel" do
       it "should perserve inserts during migration" do
         50.times { |n| execute("insert into users set reference = '#{ n }'") }

--- a/spec/integration/locked_switcher_spec.rb
+++ b/spec/integration/locked_switcher_spec.rb
@@ -16,7 +16,7 @@ describe Lhm::LockedSwitcher do
     before(:each) do
       @origin = table_create("origin")
       @destination = table_create("destination")
-      @migration = Lhm::Migration.new(@origin, @destination)
+      @migration = Lhm::Migration.new(@origin, @destination, "id")
     end
 
     it "rename origin to archive" do

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -13,7 +13,7 @@ describe Lhm::Chunker do
   before(:each) do
     @origin      = Lhm::Table.new("origin")
     @destination = Lhm::Table.new("destination")
-    @migration   = Lhm::Migration.new(@origin, @destination)
+    @migration   = Lhm::Migration.new(@origin, @destination, "id")
     @chunker     = Lhm::Chunker.new(@migration, nil, { :start => 1, :limit => 10 })
   end
 
@@ -34,7 +34,8 @@ describe Lhm::Chunker do
 
   describe "copy into with a different column to order by" do
     before(:each) do
-      @chunker     = Lhm::Chunker.new(@migration, nil, { :start => 1, :limit => 10, :order_column => 'weird_id' })
+      @migration   = Lhm::Migration.new(@origin, @destination, "weird_id")
+      @chunker     = Lhm::Chunker.new(@migration, nil, { :start => 1, :limit => 10 })
       @origin.columns["secret"] = { :metadata => "VARCHAR(255)"}
       @destination.columns["secret"] = { :metadata => "VARCHAR(255)"}
     end

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -32,6 +32,23 @@ describe Lhm::Chunker do
     end
   end
 
+  describe "copy into with a different column to order by" do
+    before(:each) do
+      @chunker     = Lhm::Chunker.new(@migration, nil, { :start => 1, :limit => 10, :order_column => 'weird_id' })
+      @origin.columns["secret"] = { :metadata => "VARCHAR(255)"}
+      @destination.columns["secret"] = { :metadata => "VARCHAR(255)"}
+    end
+
+    it "should copy the correct range and column" do
+      @chunker.copy(from = 1, to = 100).must_equal(
+        "insert ignore into `destination` (`secret`) " +
+        "select origin.`secret` from `origin` " +
+        "where origin.`weird_id` between 1 and 100"
+      )
+    end
+  end
+
+
   describe "invalid" do
     before do
       @chunker = Lhm::Chunker.new(@migration, nil, { :start => 0, :limit => -1 })

--- a/spec/unit/entangler_spec.rb
+++ b/spec/unit/entangler_spec.rb
@@ -13,7 +13,7 @@ describe Lhm::Entangler do
   before(:each) do
     @origin = Lhm::Table.new("origin")
     @destination = Lhm::Table.new("destination")
-    @migration = Lhm::Migration.new(@origin, @destination)
+    @migration = Lhm::Migration.new(@origin, @destination, "id")
     @entangler = Lhm::Entangler.new(@migration)
   end
 

--- a/spec/unit/migration_spec.rb
+++ b/spec/unit/migration_spec.rb
@@ -13,7 +13,7 @@ describe Lhm::Migration do
     @start = Time.now
     @origin = Lhm::Table.new("origin")
     @destination = Lhm::Table.new("destination")
-    @migration = Lhm::Migration.new(@origin, @destination, nil, @start)
+    @migration = Lhm::Migration.new(@origin, @destination, "id", nil, @start)
   end
 
   it "should name archive" do
@@ -22,7 +22,7 @@ describe Lhm::Migration do
   end
 
   it "should limit table name to 64 characters" do
-    migration = Lhm::Migration.new(OpenStruct.new(:name => "a_very_very_long_table_name_that_should_make_the_LHMA_table_go_over_64_chars"), nil)
+    migration = Lhm::Migration.new(OpenStruct.new(:name => "a_very_very_long_table_name_that_should_make_the_LHMA_table_go_over_64_chars"), nil, "id")
     migration.archive_name.size == 64
   end
 end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -18,11 +18,19 @@ describe Lhm::Table do
   describe "constraints" do
     it "should be satisfied with a single column primary key called id" do
       @table = Lhm::Table.new("table", "id")
+      @table.columns["id"] = {:type => "int(11)"}
       @table.satisfies_primary_key?.must_equal true
     end
 
-    it "should not be satisfied with a primary key unless called id" do
-      @table = Lhm::Table.new("table", "uuid")
+    it "should be satisfied with a primary key called something other than id" do
+      @table = Lhm::Table.new("table", "weird_id")
+      @table.columns["weird_id"] = {:type => "int(11)"}
+      @table.satisfies_primary_key?.must_equal true
+    end
+
+    it "should not be satisfied with a non numeric primary key" do
+      @table = Lhm::Table.new("table", "id")
+      @table.columns["id"] = {:type => "varchar(255)"}
       @table.satisfies_primary_key?.must_equal false
     end
 


### PR DESCRIPTION
This adds a new option to `Lhm.change_table` called `order_column`. It allows the specification of a primary key column other than `id` to use during the migration, or a to specify what column should be used in the absence of a primary key. At Shopify we're moving a whole bunch of tables over to `BIGINT(20)` sized IDs and some of our freakier tables don't have primary keys or have weird ones, so at least we need this.

Implementation wise the kind of uncomfortable state about what column to use now needs to be given to everyone. I think an appropriate place is the migration, since most objects in the system have access to it and they all need to agree on the value. This required passing the options down a couple more objects for the Migrator creating the Migration to have access, but I think thats acceptable for this increase in functionality. 

/cc @dylanahsmith @arthurnn