### PR TITLE
Ensure Lhm.cleanup removes temporary triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,17 +182,18 @@ during the run will happen on the new table as well.
 ## Cleaning up after an interrupted Lhm run
 
 If an Lhm migration is interrupted, it may leave behind the temporary tables
-used in the migration. If the migration is re-started, the unexpected presence
-of these tables will cause an error. In this case, `Lhm.cleanup` can be used
-to drop any orphaned Lhm temporary tables.
+and/or triggers used in the migration. If the migration is re-started, the
+unexpected presence of these tables will cause an error.
 
-To see what Lhm tables are found:
+In this case, `Lhm.cleanup` can be used to drop any orphaned Lhm temporary tables or triggers.
+
+To see what Lhm tables/triggers are found:
 
 ```ruby
 Lhm.cleanup
 ```
 
-To remove any Lhm tables found:
+To remove any Lhm tables/triggers found:
 ```ruby
 Lhm.cleanup(true)
 ```

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -162,7 +162,7 @@ module IntegrationHelper
   #
   # Misc
   #
-  
+
   def capture_stdout
     out = StringIO.new
     $stdout = out
@@ -170,5 +170,22 @@ module IntegrationHelper
     return out.string
   ensure
     $stdout = ::STDOUT
+  end
+
+  def simulate_failed_migration
+    Lhm::Entangler.class_eval do
+      alias_method :old_after, :after
+      def after
+        true
+      end
+    end
+
+    yield
+  ensure
+    Lhm::Entangler.class_eval do
+      undef_method :after
+      alias_method :after, :old_after
+      undef_method :old_after
+    end
   end
 end


### PR DESCRIPTION
In the event of a failed migration, triggers may not have been dropped
properly. To avoid errors, we must drop the lhm triggers before the lhm
tables.
