### PR TITLE
Add Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,10 @@
+source "https://rubygems.org"
+gemspec
+
+gem "rake"
+
+group :test do
+  gem 'activerecord'
+  gem 'mysql2'
+  gem "minitest"
+end

--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -18,8 +18,5 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.require_paths = ["lib"]
   s.executables   = ["lhm-kill-queue"]
-
-  s.add_development_dependency "minitest"
-  s.add_development_dependency "rake"
 end
 


### PR DESCRIPTION
### Problem

Was not sure about the dependencies that I had to install in order to run the specs. Tried to run `bundle install` and it didnt have any Gemfile.
### Solution

Add Gemfile, so it can install all dev dependencies easier

cc @edmundsalvacion @pellegrino @mortice
