### PR TITLE
Adding a module wide logger, and setup logic.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pkg/*
 .rvmrc
 .ruby-version
 .ruby-gemset
+omg.ponies

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -5,6 +5,7 @@ require 'lhm/table'
 require 'lhm/invoker'
 require 'lhm/connection'
 require 'lhm/version'
+require 'logger'
 
 # Large hadron migrator - online schema change tool
 #
@@ -17,6 +18,7 @@ require 'lhm/version'
 #   end
 #
 module Lhm
+  DEFAULT_LOGGER_OPTIONS =  { level: Logger::INFO, file: STDOUT }
 
   # Alters a table with the changes described in the block
   #
@@ -71,6 +73,20 @@ module Lhm
       begin
         raise 'Please call Lhm.setup' unless defined?(ActiveRecord)
         ActiveRecord::Base.connection
+      end
+  end
+
+  def self.logger=(new_logger)
+    @@logger = new_logger
+  end
+
+  def self.logger
+    @@logger ||= 
+      begin
+        logger = Logger.new(DEFAULT_LOGGER_OPTIONS[:file])
+        logger.level = DEFAULT_LOGGER_OPTIONS[:level]
+        logger.formatter = nil
+        logger
       end
   end
 

--- a/lib/lhm/command.rb
+++ b/lib/lhm/command.rb
@@ -7,6 +7,7 @@ module Lhm
 
   module Command
     def run(&block)
+      Lhm.logger.info "Starting run of class=#{self.class}"
       validate
 
       if(block_given?)
@@ -16,7 +17,8 @@ module Lhm
       else
         execute
       end
-    rescue
+    rescue => e
+      Lhm.logger.error "Error in class=#{self.class}, reverting. exception=#{e.class} message=#{e.message}"
       revert
       raise
     end

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -24,6 +24,8 @@ module Lhm
     end
 
     def run(options = {})
+      Lhm.logger.info "Starting LHM run on table=#{@migrator.name}"
+
       if !options.include?(:atomic_switch)
         if supports_atomic_switch?
           options[:atomic_switch] = true
@@ -44,6 +46,10 @@ module Lhm
           LockedSwitcher.new(migration, @connection).run
         end
       end
+
+    rescue => e
+      Lhm.logger.error "LHM run failed with exception=#{e.class} message=#{e.message}"
+      raise
     end
   end
 end

--- a/spec/unit/lhm_spec.rb
+++ b/spec/unit/lhm_spec.rb
@@ -1,0 +1,31 @@
+require File.expand_path(File.dirname(__FILE__)) + '/unit_helper'
+
+require 'lhm'
+
+
+describe Lhm do
+
+  before(:each) do
+    Lhm.remove_class_variable :@@logger if Lhm.class_variable_defined? :@@logger
+  end
+
+  describe "logger" do
+
+    it "should use the default parameters if no logger explicitly set" do
+      Lhm.logger.must_be_kind_of Logger
+      Lhm.logger.level.must_equal Logger::INFO
+      Lhm.logger.instance_eval{ @logdev }.dev.must_equal STDOUT
+    end
+
+    it "should use s new logger if set" do
+      l = Logger.new('omg.ponies')
+      l.level = Logger::ERROR
+      Lhm.logger = l
+
+      Lhm.logger.level.must_equal Logger::ERROR
+      Lhm.logger.instance_eval{ @logdev }.dev.must_be_kind_of File
+      Lhm.logger.instance_eval{ @logdev }.dev.path.must_equal 'omg.ponies'
+    end
+
+  end
+end


### PR DESCRIPTION
We have found that having logs would improve our workflow. 

This commit simply adds a Lhm wide logger, which is just a simple ruby Logger instance, it must be configured once before the first call to Lhm.logger, via the Lhm.logger_params accessor, probably from a Rails initializer.

@arthurnn review plz
