### PR TITLE
Allow for optional time filter on .cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,18 @@ To remove any Lhm tables/triggers found:
 Lhm.cleanup(true)
 ```
 
+Optionally only remove tables up to a specific Time, if you want to retain previous migrations.
+
+Rails:
+```ruby
+Lhm.cleanup(true, until: 1.day.ago)
+```
+
+Ruby:
+```ruby
+Lhm.cleanup(true, until: Time.now - 86400)
+```
+
 ## Contributing
 
 First, get set up for local development:

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -51,8 +51,21 @@ module Lhm
     true
   end
 
-  def cleanup(run = false)
+  # Cleanup tables and triggers
+  #
+  # @param [Boolean] run execute now or just display information
+  # @param [Hash] options Optional options to alter cleanup behaviour
+  # @option options [Time] :until
+  #   Filter to only remove tables up to specified time (defaults to: nil)
+  def cleanup(run = false, options = {})
     lhm_tables = connection.select_values("show tables").select { |name| name =~ /^lhm(a|n)_/ }
+    if options[:until]
+      lhm_tables.select!{ |table|
+        table_date_time = Time.strptime(table, "lhma_%Y_%m_%d_%H_%M_%S")
+        table_date_time <= options[:until]
+      }
+    end
+
     lhm_triggers = connection.select_values("show triggers").collect do |trigger|
       trigger.respond_to?(:trigger) ? trigger.trigger : trigger
     end.select { |name| name =~ /^lhmt/ }

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -30,6 +30,30 @@ describe Lhm, "cleanup" do
       output.must_match(/lhma_[0-9_]*_users/)
     end
 
+    it "should show temporary tables within range" do
+      table = OpenStruct.new(:name => 'users')
+      table_name = Lhm::Migration.new(table, nil, nil, Time.now - 172800).archive_name
+      table_rename(:users, table_name)
+
+      output = capture_stdout do
+        Lhm.cleanup false, {:until => Time.now - 86400}
+      end
+      output.must_include("Existing LHM backup tables")
+      output.must_match(/lhma_[0-9_]*_users/)
+    end
+
+    it "should exclude temporary tables outside range" do
+      table = OpenStruct.new(:name => 'users')
+      table_name = Lhm::Migration.new(table, nil, nil, Time.now).archive_name
+      table_rename(:users, table_name)
+
+      output = capture_stdout do
+        Lhm.cleanup false, {:until => Time.now - 172800}
+      end
+      output.must_include("Existing LHM backup tables")
+      output.wont_match(/lhma_[0-9_]*_users/)
+    end
+
     it "should show temporary triggers" do
       output = capture_stdout do
         Lhm.cleanup

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -104,6 +104,10 @@ module IntegrationHelper
     table_read(fixture_name)
   end
 
+  def table_rename(from_name, to_name)
+    execute "rename table `#{ from_name }` to `#{ to_name }`"
+  end
+
   def table_read(fixture_name)
     Lhm::Table.parse(fixture_name, @connection)
   end


### PR DESCRIPTION
We're keen on automatically cleaning up Triggers and Tables, but it would be nice to retain some recent tables

This PR introduces an optional options hash to .cleanup to allow for a until_time where tables created afterwards would be preserved
