### PR TITLE
Ensure that single record tables are correctly copied.

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -25,7 +25,7 @@ module Lhm
     def execute
       return unless @start && @limit
       @next_to_insert = @start
-      until @next_to_insert >= @limit
+      while @next_to_insert < @limit || (@next_to_insert == 1 && @start == 1)
         stride = @throttler.stride
         affected_rows = @connection.update(copy(bottom, top(stride)))
 

--- a/spec/unit/chunker_spec.rb
+++ b/spec/unit/chunker_spec.rb
@@ -84,6 +84,19 @@ describe Lhm::Chunker do
       @connection.verify
     end
 
+    it 'correctly copies single record tables' do
+      @chunker = Lhm::Chunker.new(@migration, @connection, :throttler => @throttler,
+                                                           :start     => 1,
+                                                           :limit     => 1)
+
+      @connection.expect(:update, 1) do |stmt|
+        stmt.first =~ /between 1 and 1/
+      end
+
+      @chunker.run
+      @connection.verify
+    end
+
     it "separates filter conditions from chunking conditions" do
       @chunker = Lhm::Chunker.new(@migration, @connection, :throttler => @throttler,
                                                            :start     => 1,


### PR DESCRIPTION
This is a rare corner case, but it was sending me down the rabbit hole in spec testing.
