### PR TITLE
Make the primary key to use for the migration configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * #93 - Makes the atomic switcher retry on metadata locks (@camilo)
 * #63 - Sets the LHM's session lock wait timeout variables (@camilo)
 * #75 - Remove DataMapper and ActiveRecord 2.x support (@camilo)
+* #73 - Allow configuration of the primary key used in migrations (@airhorns)
 
 # 2.2.0 (Jan 16, 2015)
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ without locking the table. In contrast to [OAK][0] and the
 [facebook tool][1], we only use a copy table and triggers.
 
 The Large Hadron is a test driven Ruby solution which can easily be dropped
-into an ActiveRecord or DataMapper migration. It presumes a single auto
-incremented numerical primary key called id as per the Rails convention. Unlike
-the [twitter solution][2], it does not require the presence of an indexed
-`updated_at` column.
+into an ActiveRecord or DataMapper migration. It presumes an auto incremented
+numerical primary key (such as id by Rails conventions). Unlike the [twitter
+solution][2], it does not require the presence of an indexed `updated_at`
+column.
 
 ## Requirements
 
@@ -51,7 +51,7 @@ ActiveRecord 3.2.x and 4.x (mysql and mysql2 adapters).
 ## Limitations
 
 Due to the Chunker implementation, Lhm requires that the table to migrate has a
-a monotonically increasing numeric key column called `id`.
+a monotonically increasing numeric column.
 
 ## Installation
 

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -40,12 +40,14 @@ module Lhm
   #   Use atomic switch to rename tables (defaults to: true)
   #   If using a version of mysql affected by atomic switch bug, LHM forces user
   #   to set this option (see SqlHelper#supports_atomic_switch?)
+  # @option options [String] :order_column
+  #   Column name to order records by. This column must be unique for every record (defaults to: "id")
   # @yield [Migrator] Yielded Migrator object records the changes
   # @return [Boolean] Returns true if the migration finishes
   # @raise [Error] Raises Lhm::Error in case of a error and aborts the migration
   def change_table(table_name, options = {}, &block)
     origin = Table.parse(table_name, connection)
-    invoker = Invoker.new(origin, connection)
+    invoker = Invoker.new(origin, connection, options)
     block.call(invoker.migrator)
     invoker.run(options)
     true

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -52,16 +52,16 @@ module Lhm
     def copy(lowest, highest)
       "insert ignore into `#{ destination_name }` (#{ destination_columns }) " \
       "select #{ origin_columns } from `#{ origin_name }` " \
-      "#{ conditions } `#{ origin_name }`.`id` between #{ lowest } and #{ highest }"
+      "#{ conditions } `#{ origin_name }`.`#{ @migration.order_column }` between #{ lowest } and #{ highest }"
     end
 
     def select_start
-      start = connection.select_value("select min(id) from `#{ origin_name }`")
+      start = connection.select_value("select min(#{ @migration.order_column }) from `#{ origin_name }`")
       start ? start.to_i : nil
     end
 
     def select_limit
-      limit = connection.select_value("select max(id) from `#{ origin_name }`")
+      limit = connection.select_value("select max(#{ @migration.order_column }) from `#{ origin_name }`")
       limit ? limit.to_i : nil
     end
 

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -17,6 +17,7 @@ module Lhm
       @intersection = migration.intersection
       @origin = migration.origin
       @destination = migration.destination
+      @order_column = migration.order_column
       @connection = connection
     end
 
@@ -59,7 +60,7 @@ module Lhm
         create trigger `#{ trigger(:del) }`
         after delete on `#{ @origin.name }` for each row
         delete ignore from `#{ @destination.name }` #{ SqlHelper.annotation }
-        where `#{ @destination.name }`.`id` = OLD.`id`
+        where `#{ @destination.name }`.`#{ @order_column }` = OLD.`#{ @order_column }`
       }
     end
 

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -19,9 +19,9 @@ module Lhm
 
     attr_reader :migrator, :connection
 
-    def initialize(origin, connection)
+    def initialize(origin, connection, options)
       @connection = connection
-      @migrator = Migrator.new(origin, connection)
+      @migrator = Migrator.new(origin, connection, options)
     end
 
     def set_session_lock_wait_timeouts

--- a/lib/lhm/migration.rb
+++ b/lib/lhm/migration.rb
@@ -5,12 +5,13 @@ require 'lhm/intersection'
 
 module Lhm
   class Migration
-    attr_reader :origin, :destination, :conditions, :renames
+    attr_reader :origin, :destination, :conditions, :renames, :order_column
 
-    def initialize(origin, destination, conditions = nil, renames = {}, time = Time.now)
+    def initialize(origin, destination, order_column, conditions = nil, renames = {}, time = Time.now)
       @origin = origin
       @destination = destination
       @conditions = conditions
+      @order_column = order_column
       @start = time
       @renames = renames
     end

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -16,9 +16,11 @@ module Lhm
     end
 
     def satisfies_id_autoincrement_requirement?
-      !!((id = columns['id']) &&
-        id[:extra] == 'auto_increment' &&
-        id[:type] =~ /int\(\d+\)/)
+      monotonically_increasing_numeric_key?(columns["id"])
+    end
+
+    def can_use_order_column?(column_name)
+      monotonically_increasing_numeric_key?(columns[column_name])
     end
 
     def destination_name
@@ -109,8 +111,18 @@ module Lhm
           defn[column_name]
         end
 
-        keys.length == 1 ? keys.first : keys
+        case keys.length
+        when 0 then nil
+        when 1 then keys.first
+        else keys
+        end
       end
+    end
+
+    def monotonically_increasing_numeric_key?(key)
+      !!(key &&
+         key[:extra] == 'auto_increment' &&
+         key[:type] =~ /int\(\d+\)/)
     end
   end
 end

--- a/spec/fixtures/no_primary_key.ddl
+++ b/spec/fixtures/no_primary_key.ddl
@@ -1,0 +1,4 @@
+CREATE TABLE `no_primary_key` (
+  `foreign_id` int(11) NOT NULL,
+  `value` int(11) NOT NULL DEFAULT '0'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/primary_keys.ddl
+++ b/spec/fixtures/primary_keys.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `primary_keys` (
+  `weird_id` int(11) NOT NULL AUTO_INCREMENT,
+  `origin` int(11) DEFAULT NULL,
+  `common` varchar(255) DEFAULT NULL,
+  PRIMARY KEY (`weird_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -17,7 +17,7 @@ describe Lhm::AtomicSwitcher do
       Thread.abort_on_exception = true
       @origin      = table_create("origin")
       @destination = table_create("destination")
-      @migration   = Lhm::Migration.new(@origin, @destination)
+      @migration   = Lhm::Migration.new(@origin, @destination, "id")
       Lhm.logger = Logger.new('/dev/null')
       @connection.execute("SET GLOBAL innodb_lock_wait_timeout=3")
       @connection.execute("SET GLOBAL lock_wait_timeout=3")

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -14,7 +14,7 @@ describe Lhm::Chunker do
     before(:each) do
       @origin = table_create(:origin)
       @destination = table_create(:destination)
-      @migration = Lhm::Migration.new(@origin, @destination)
+      @migration = Lhm::Migration.new(@origin, @destination, "id")
     end
 
     it 'should copy 23 rows from origin to destination with time based throttler' do

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -32,7 +32,7 @@ describe Lhm, 'cleanup' do
 
     it 'should show temporary tables within range' do
       table = OpenStruct.new(:name => 'users')
-      table_name = Lhm::Migration.new(table, nil, nil, {}, Time.now - 172800).archive_name
+      table_name = Lhm::Migration.new(table, nil, nil, nil, Time.now - 172800).archive_name
       table_rename(:users, table_name)
 
       output = capture_stdout do
@@ -44,7 +44,7 @@ describe Lhm, 'cleanup' do
 
     it 'should exclude temporary tables outside range' do
       table = OpenStruct.new(:name => 'users')
-      table_name = Lhm::Migration.new(table, nil, nil, {}, Time.now).archive_name
+      table_name = Lhm::Migration.new(table, nil, nil, nil, Time.now).archive_name
       table_rename(:users, table_name)
 
       output = capture_stdout do

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -14,9 +14,9 @@ describe Lhm::Entangler do
 
   describe 'entanglement' do
     before(:each) do
-      @origin = table_create('origin')
-      @destination = table_create('destination')
-      @migration = Lhm::Migration.new(@origin, @destination)
+      @origin = table_create("origin")
+      @destination = table_create("destination")
+      @migration = Lhm::Migration.new(@origin, @destination, "id")
       @entangler = Lhm::Entangler.new(@migration, connection)
     end
 

--- a/spec/integration/lock_wait_timeout_spec.rb
+++ b/spec/integration/lock_wait_timeout_spec.rb
@@ -16,7 +16,7 @@ describe Lhm do
     global_innodb_lock_wait_timeout = connection.execute("SHOW GLOBAL VARIABLES LIKE 'innodb_lock_wait_timeout'").first.last.to_i
     global_lock_wait_timeout = connection.execute("SHOW GLOBAL VARIABLES LIKE 'lock_wait_timeout'").first.last.to_i
 
-    invoker = Lhm::Invoker.new(Lhm::Table.parse(:users, connection), connection)
+    invoker = Lhm::Invoker.new(Lhm::Table.parse(:users, connection), connection, nil)
     invoker.set_session_lock_wait_timeouts
 
     session_innodb_lock_wait_timeout = connection.execute("SHOW SESSION VARIABLES LIKE 'innodb_lock_wait_timeout'").first.last.to_i

--- a/spec/integration/locked_switcher_spec.rb
+++ b/spec/integration/locked_switcher_spec.rb
@@ -22,9 +22,9 @@ describe Lhm::LockedSwitcher do
 
   describe 'switching' do
     before(:each) do
-      @origin = table_create('origin')
-      @destination = table_create('destination')
-      @migration = Lhm::Migration.new(@origin, @destination)
+      @origin = table_create("origin")
+      @destination = table_create("destination")
+      @migration = Lhm::Migration.new(@origin, @destination, "id")
     end
 
     it 'rename origin to archive' do

--- a/spec/unit/entangler_spec.rb
+++ b/spec/unit/entangler_spec.rb
@@ -11,9 +11,9 @@ describe Lhm::Entangler do
   include UnitHelper
 
   before(:each) do
-    @origin = Lhm::Table.new('origin')
-    @destination = Lhm::Table.new('destination')
-    @migration = Lhm::Migration.new(@origin, @destination)
+    @origin = Lhm::Table.new("origin")
+    @destination = Lhm::Table.new("destination")
+    @migration = Lhm::Migration.new(@origin, @destination, "id")
     @entangler = Lhm::Entangler.new(@migration)
   end
 

--- a/spec/unit/migration_spec.rb
+++ b/spec/unit/migration_spec.rb
@@ -11,9 +11,9 @@ describe Lhm::Migration do
 
   before(:each) do
     @start = Time.now
-    @origin = Lhm::Table.new('origin')
-    @destination = Lhm::Table.new('destination')
-    @migration = Lhm::Migration.new(@origin, @destination, nil, @start)
+    @origin = Lhm::Table.new("origin")
+    @destination = Lhm::Table.new("destination")
+    @migration = Lhm::Migration.new(@origin, @destination, "id", nil, @start)
   end
 
   it 'should name archive' do
@@ -21,8 +21,8 @@ describe Lhm::Migration do
     @migration.archive_name.must_equal "lhma_#{ @start.strftime(stamp) }_origin"
   end
 
-  it 'should limit table name to 64 characters' do
-    migration = Lhm::Migration.new(OpenStruct.new(:name => 'a_very_very_long_table_name_that_should_make_the_LHMA_table_go_over_64_chars'), nil)
+  it "should limit table name to 64 characters" do
+    migration = Lhm::Migration.new(OpenStruct.new(:name => "a_very_very_long_table_name_that_should_make_the_LHMA_table_go_over_64_chars"), nil, "id")
     migration.archive_name.size == 64
   end
 end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -15,26 +15,28 @@ describe Lhm::Table do
     end
   end
 
-  describe 'constraints' do
+  describe "constraints" do
     def set_columns(table, columns)
       table.instance_variable_set('@columns', columns)
     end
 
-    it 'should be satisfied with a single column primary key called id' do
-      @table = Lhm::Table.new('table', 'id')
+    it "should be satisfied with a single column primary key called id" do
+      @table = Lhm::Table.new("table", "id")
+      @table.columns["id"] = {:type => "int(11)"}
       set_columns(@table, { 'id' => { :type => 'int(1)', :extra => 'auto_increment' } })
       @table.satisfies_id_autoincrement_requirement?.must_equal true
     end
 
-    it 'should be satisfied with a primary key not called id, as long as there is still an id' do
-      @table = Lhm::Table.new('table', 'uuid')
-      set_columns(@table, { 'id' => { :type => 'int(1)', :extra => 'auto_increment' } })
-      @table.satisfies_id_autoincrement_requirement?.must_equal true
+    it "should be satisfied with a primary key called something other than id" do
+      @table = Lhm::Table.new("table", "weird_id")
+      set_columns(@table, { 'weird_id' => { :type => "int(1)", :extra => 'auto_increment' } })
+      @table.satisfies_id_autoincrement_requirement?.must_equal false
+      @table.can_use_order_column?('weird_id').must_equal true
     end
 
-    it 'should not be satisfied if id is not numeric' do
-      @table = Lhm::Table.new('table', 'id')
-      set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
+    it "should not be satisfied with a non numeric primary key" do
+      @table = Lhm::Table.new("table", "id")
+      set_columns(@table, { 'id' => {:type => "varchar(255)"} })
       @table.satisfies_id_autoincrement_requirement?.must_equal false
     end
 
@@ -42,6 +44,13 @@ describe Lhm::Table do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
       @table.satisfies_id_autoincrement_requirement?.must_equal false
+    end
+
+    it "should not be satisfied with a non numeric key called something other than id" do
+      @table = Lhm::Table.new("table", "weird_id")
+      set_columns(@table, { 'weird_id' => { :type => "varchar(255)" } })
+      @table.satisfies_id_autoincrement_requirement?.must_equal false
+      @table.can_use_order_column?('weird_id').must_equal false
     end
   end
 end


### PR DESCRIPTION
This a squashed and rebased version of soundcloud/lhm#49, since @airhorns seems unreachable.
There were a few conflicts, which I've resolved. It'd be great if we can get this looked at again!

---
#49

> Instead of relying on a table to have a primary key, we now accept the
> order_column option and put that everywhere. This kind of uncomfortable
> state about the migration now needs to be given to everyone and I think
> an appropriate place is the migration, since most objects in the system
> have access to it and they all need to agree on the value. This required
> passing the options down a couple more objects for the Migrator creating
> the Migration to have access, but I think thats acceptable for this
> increase in functionality.
