### PR TITLE
Add support for multiple outbound foreign keys constraints

### DIFF
--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -207,9 +207,7 @@ module Lhm
     end
 
     def destination_create
-      original    = %{CREATE TABLE `#{ @origin.name }`}
-      replacement = %{CREATE TABLE `#{ @origin.destination_name }`}
-      stmt = @origin.ddl.gsub(original, replacement)
+      stmt = @origin.destination_ddl
       @connection.execute(tagged(stmt))
     end
 

--- a/spec/fixtures/fk_example.ddl
+++ b/spec/fixtures/fk_example.ddl
@@ -1,0 +1,8 @@
+CREATE TABLE `fk_example` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `master_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_example_ibfk_1` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_example_ibfk_2` FOREIGN KEY (`master_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/fk_example_second_pass.ddl
+++ b/spec/fixtures/fk_example_second_pass.ddl
@@ -1,0 +1,8 @@
+CREATE TABLE `fk_example_second_pass` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `master_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_example_ibfk_1_lhmn` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`),
+  CONSTRAINT `fk_example_ibfk_2_lhmn` FOREIGN KEY (`master_id`) REFERENCES `users` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/integration/foreign_keys_spec.rb
+++ b/spec/integration/foreign_keys_spec.rb
@@ -1,0 +1,89 @@
+# Copyright (c) 2011 - 2013, SoundCloud Ltd., Rany Keddo, Tobias Bielohlawek, Tobias
+# Schmidt
+
+require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
+
+require 'lhm'
+
+describe Lhm do
+  include IntegrationHelper
+
+  before(:each) do
+    connect_master!
+    Lhm.cleanup(true)
+    %w(fk_example fk_example_second_pass).each do |table|
+      execute "drop table if exists #{table}"
+    end
+    table_create(:users)
+  end
+
+  describe 'the simplest case' do
+    before(:each) do
+      table_create(:fk_example)
+    end
+
+    after(:each) do
+      execute 'drop table if exists fk_example'
+      Lhm.cleanup(true)
+    end
+
+    it 'should handle tables with foreign keys by appending the suffix' do
+      Lhm.change_table(:fk_example) do |t|
+        t.add_column(:new_column, "INT(12) DEFAULT '0'")
+      end
+
+      slave do
+        actual = table_read(:fk_example).constraints['user_id']
+        expected = {
+          name: 'fk_example_ibfk_1_lhmn',
+          referenced_table: 'users',
+          referenced_column: 'id',
+        }
+        hash_slice(actual, expected.keys).must_equal(expected)
+
+        actual = table_read(:fk_example).constraints['master_id']
+        expected = {
+          name: 'fk_example_ibfk_2_lhmn',
+          referenced_table: 'users',
+          referenced_column: 'id',
+        }
+        hash_slice(actual, expected.keys).must_equal(expected)
+      end
+    end
+  end
+
+  describe 'manage a new migration by removing the suffix' do
+    before(:each) do
+      table_create(:fk_example_second_pass)
+    end
+
+    after(:each) do
+      execute 'drop table if exists fk_example_second_pass'
+      Lhm.cleanup(true)
+    end
+
+    it 'should be able to create this table' do
+      Lhm.change_table(:fk_example_second_pass) do |t|
+        t.add_column(:new_column, "INT(12) DEFAULT '0'")
+      end
+
+      slave do
+        actual = table_read(:fk_example_second_pass).constraints['user_id']
+        expected = {
+          name: 'fk_example_ibfk_1',
+          referenced_table: 'users',
+          referenced_column: 'id',
+        }
+        hash_slice(actual, expected.keys).must_equal(expected)
+
+        actual = table_read(:fk_example_second_pass).constraints['master_id']
+        expected = {
+          name: 'fk_example_ibfk_2',
+          referenced_table: 'users',
+          referenced_column: 'id',
+        }
+        hash_slice(actual, expected.keys).must_equal(expected)
+      end
+    end
+  end
+end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -125,6 +125,11 @@ module IntegrationHelper
     connection.table_exists?(table.name)
   end
 
+  def hash_slice(hash, keys)
+    return hash.slice(*keys) if hash.respond_to?(:slice)
+    keys.each { |k| [k, hash[k]] }.to_h
+  end
+
   #
   # Database Helpers
   #

--- a/spec/integration/table_spec.rb
+++ b/spec/integration/table_spec.rb
@@ -86,6 +86,23 @@ describe Lhm::Table do
           indices['index_users_on_reference'].
           must_equal(['reference'])
       end
+
+      it 'should parse constraints' do
+        begin
+          @table = table_create(:fk_example)
+          @table.constraints.keys.must_equal %w(user_id master_id)
+
+          expected = {
+            name: 'fk_example_ibfk_1',
+            referenced_table: 'users',
+            referenced_column: 'id'
+          }
+
+          hash_slice(@table.constraints['user_id'], expected.keys).must_equal expected
+        ensure
+          execute 'drop table if exists fk_example'
+        end
+      end
     end
   end
 end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -15,25 +15,38 @@ describe Lhm::Table do
     end
   end
 
+  describe 'ddl' do
+    it 'should build the destination table' do
+      table = 'users'
+      schema = 'default'
+
+      @table = Lhm::Table.new(table, schema, 'id', %Q{CREATE TABLE `#{table}` (random_constraint)})
+      @table.constraints['user_id'] = {:name => 'random_constraint', :referenced_column => true}
+      Lhm::Table.schema_constraints(schema, {'random_constraint_lhmn' => true})
+
+      @table.destination_ddl.must_equal %Q{CREATE TABLE `#{@table.destination_name}` (random_constraint_lhmn)}
+    end
+  end
+
   describe 'constraints' do
     def set_columns(table, columns)
       table.instance_variable_set('@columns', columns)
     end
 
     it 'should be satisfied with a single column primary key called id' do
-      @table = Lhm::Table.new('table', 'id')
+      @table = Lhm::Table.new('table', 'default', 'id')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
       @table.satisfies_id_column_requirement?.must_equal true
     end
 
     it 'should be satisfied with a primary key not called id, as long as there is still an id' do
-      @table = Lhm::Table.new('table', 'uuid')
+      @table = Lhm::Table.new('table', 'default', 'uuid')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
       @table.satisfies_id_column_requirement?.must_equal true
     end
 
     it 'should not be satisfied if id is not numeric' do
-      @table = Lhm::Table.new('table', 'id')
+      @table = Lhm::Table.new('table', 'default', 'id')
       set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
       @table.satisfies_id_column_requirement?.must_equal false
     end


### PR DESCRIPTION
This adds support for tables with multiples outbound foreign keys constraints. This is a modification of pull request #36 who allowed only one foreign key constraint.

The original problem in issue #34 was that lhm tries to create a table with foreign keys constraint having the same name than the original table, producing an error. #36 tried to fix it by modifying the last number at the end of the name. `table_ibfk_1` would then become `table_ibfk_2`.
The problem was that the new constraints names were the same when the table had more than one outbound foreign keys, producing the same error than before. Another problem with that solution is that the names produced are not consistent when you undo or redo a migration. The original names are lost forever, so undo a migration won't give you the same structure than before. The new name depends on the original name, so redo a migration may not give the same structure either.

My solution appends a suffix "_lhmn" to the constraint name. If the suffix is already there, we remove it in the new name. If you apply two `change_table`, the constraint names will then be exactly as before. This allows migrations undo and redo to work as they should. Besides, the uniqueness of constraints names is no longer a problem, making lhm support as many outbound foreign key constraints as necessary.
