### PR TITLE
Fix bug migrating tables with only a single record

### DIFF
--- a/bin/lhm-spec-clobber.sh
+++ b/bin/lhm-spec-clobber.sh
@@ -9,12 +9,12 @@ lhmkill() {
   echo killing lhm-cluster
   ps -ef | sed -n "/[m]ysqld.*lhm-cluster/p" | awk '{ print $2 }' | xargs kill
   echo running homebrew mysql instance
-  launchctl load -w ~/Library/LaunchAgents/homebrew.mxcl.mysql.plist
+  ls -lrt -d -1 ~/Library/LaunchAgents/* |  grep -e 'mysql|mariadb.plist' | xargs launchctl load -w
   sleep 2
 }
 
 echo stopping homebrew running mysql instance
-ls -lrt -d -1 ~/Library/LaunchAgents/* |  grep 'mysql.plist' | xargs launchctl unload -w
+ls -lrt -d -1 ~/Library/LaunchAgents/* |  grep -e 'mysql|mariadb.plist' | xargs launchctl unload -w
 
 lhmkill
 

--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -25,7 +25,7 @@ module Lhm
     def execute
       return unless @start && @limit
       @next_to_insert = @start
-      until @next_to_insert >= @limit
+      until (@next_to_insert >= @limit) && @next_to_insert > 1
         stride = @throttler.stride
         affected_rows = @connection.update(copy(bottom, top(stride)))
 

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -81,6 +81,8 @@ describe Lhm do
 
     it "should copy even 1 row" do
       execute("insert into users set reference = '1'")
+      select_value("select id from users").must_equal(1)
+      select_value("select reference from users LIMIT 1").must_equal(1)
 
       Lhm.change_table(:users, :atomic_switch => false) do |t|
         t.add_column(:logins, "INT(12) DEFAULT '0'")
@@ -88,6 +90,13 @@ describe Lhm do
 
       slave do
         count_all(:users).must_equal(1)
+        table_read(:users).columns["logins"].must_equal({
+          :type => "int(12)",
+          :is_nullable => "YES",
+          :column_default => "0"
+        })
+        select_value("select id from users LIMIT 1").must_equal(1)
+        select_value("select reference from users LIMIT 1").must_equal(1)
       end
     end
 

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -79,6 +79,18 @@ describe Lhm do
       end
     end
 
+    it "should copy even 1 row" do
+      execute("insert into users set reference = '1'")
+
+      Lhm.change_table(:users, :atomic_switch => false) do |t|
+        t.add_column(:logins, "INT(12) DEFAULT '0'")
+      end
+
+      slave do
+        count_all(:users).must_equal(1)
+      end
+    end
+
     it "should remove a column" do
       Lhm.change_table(:users, :atomic_switch => false) do |t|
         t.remove_column(:comment)


### PR DESCRIPTION
![](http://media.giphy.com/media/aAsOxi5ZVPpgA/giphy.gif)

## What? Why?

I ran into a bug when running Lhm.change_table against a table with only a single record.

In this case, both the `next_to_start` and the`limit` variables (in Chunker#execute) are the same thus never triggering the copy.

## What should be tested?

You can properly migrate tables with only 1 record using Lhm#change_table.

Note: I forked off off tag v2.1.0 (which is what [we](https://redbooth.com) are using right now). A bit busy to do it again for master but I can do so in a week or so.
