### PR TITLE
Raise an error when index name isn't a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # 2.2.0
 
+* Require index names to be strings or symbols (Thibaut)
 * Adding the ability to rename columns (erikogan)
 * Allow for optional time filter on .cleanup (joelr)
 

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -214,10 +214,17 @@ module Lhm
     end
 
     def index_ddl(cols, unique = nil, index_name = nil)
+      assert_valid_idx_name(index_name)
       type = unique ? "unique index" : "index"
       index_name ||= idx_name(@origin.name, cols)
       parts = [type, index_name, @name, idx_spec(cols)]
       "create %s `%s` on `%s` (%s)" % parts
+    end
+
+    def assert_valid_idx_name(index_name)
+      if index_name && !(index_name.is_a?(String) || index_name.is_a?(Symbol))
+        raise ArgumentError, "index_name must be a string or symbol"
+      end
     end
   end
 end

--- a/spec/unit/migrator_spec.rb
+++ b/spec/unit/migrator_spec.rb
@@ -47,6 +47,12 @@ describe Lhm::Migrator do
       ])
     end
 
+    it "should raise an error when the index name is not a string or symbol" do
+      assert_raises ArgumentError do
+        @creator.add_index([:a, :b], :name => :custom_index_name)
+      end
+    end
+
     it "should add a unique index" do
       @creator.add_unique_index(["a(5)", :b])
 
@@ -61,6 +67,12 @@ describe Lhm::Migrator do
       @creator.statements.must_equal([
         "create unique index `custom_index_name` on `lhmn_alt` (`a`, `b`)"
       ])
+    end
+
+    it "should raise an error when the unique index name is not a string or symbol" do
+      assert_raises ArgumentError do
+        @creator.add_unique_index([:a, :b], :name => :custom_index_name)
+      end
     end
 
     it "should remove an index" do


### PR DESCRIPTION
Rails's `add_index` takes an option hash as last argument instead of an index name, so people sometimes do this:

``` ruby
Lhm.change_table :foo do |m|
  m.add_index [:bar], name: 'name'
end
```

expecting an index named `name` to be created, but it actually ends up with the name `{:name=>"name"}`.

Since changing the signature of `add_index` is a breaking change, I've instead made it raise an exception when the index isn't a string or symbol.

@arthurnn 
