### PR TITLE
Change schema validation to match actual requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ running the migrations.
 
 ## Limitations
 
-Lhm requires a monotonically increasing numeric Primary Key on the table, due to how
-the Chunker works.
+Due to the Chunker implementation, Lhm requires that the table to migrate has a
+a monotonically increasing numeric key column called `id`.
 
 ## Installation
 

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -187,7 +187,7 @@ module Lhm
         error("could not find origin table #{ @origin.name }")
       end
 
-      unless @origin.satisfies_primary_key?
+      unless @origin.satisfies_id_autoincrement_requirement?
         error('origin does not satisfy primary key requirements')
       end
 

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -15,8 +15,10 @@ module Lhm
       @ddl = ddl
     end
 
-    def satisfies_primary_key?
-      @pk == 'id'
+    def satisfies_id_autoincrement_requirement?
+      !!((id = columns['id']) &&
+        id[:extra] == 'auto_increment' &&
+        id[:type] =~ /int\(\d+\)/)
     end
 
     def destination_name
@@ -49,10 +51,13 @@ module Lhm
             column_type    = struct_key(defn, 'COLUMN_TYPE')
             is_nullable    = struct_key(defn, 'IS_NULLABLE')
             column_default = struct_key(defn, 'COLUMN_DEFAULT')
+            extra          = struct_key(defn, 'EXTRA')
+
             table.columns[defn[column_name]] = {
               :type => defn[column_type],
               :is_nullable => defn[is_nullable],
-              :column_default => defn[column_default]
+              :column_default => defn[column_default],
+              :extra => defn[extra]
             }
           end
 

--- a/spec/fixtures/custom_primary_key.ddl
+++ b/spec/fixtures/custom_primary_key.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `custom_primary_key` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `pk` varchar(255),
+  PRIMARY KEY (`pk`),
+  UNIQUE KEY `index_custom_primary_key_on_id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/small_table.ddl
+++ b/spec/fixtures/small_table.ddl
@@ -1,4 +1,4 @@
 CREATE TABLE `small_table` (
-  `id` INT(11),
+  `id` INT(11) auto_increment,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/wo_mon_inc_num.ddl
+++ b/spec/fixtures/wo_mon_inc_num.ddl
@@ -1,0 +1,7 @@
+-- Without auto increment
+CREATE TABLE `wo_mon_inc_num` (
+  `id` int(11) NOT NULL,
+  `pk` varchar(255),
+  PRIMARY KEY (`pk`),
+  UNIQUE KEY `index_custom_primary_key_on_id` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -16,19 +16,32 @@ describe Lhm::Table do
   end
 
   describe 'constraints' do
+    def set_columns(table, columns)
+      table.instance_variable_set('@columns', columns)
+    end
+
     it 'should be satisfied with a single column primary key called id' do
       @table = Lhm::Table.new('table', 'id')
-      @table.satisfies_primary_key?.must_equal true
+      set_columns(@table, { 'id' => { :type => 'int(1)', :extra => 'auto_increment' } })
+      @table.satisfies_id_autoincrement_requirement?.must_equal true
     end
 
-    it 'should not be satisfied with a primary key unless called id' do
+    it 'should be satisfied with a primary key not called id, as long as there is still an id' do
       @table = Lhm::Table.new('table', 'uuid')
-      @table.satisfies_primary_key?.must_equal false
+      set_columns(@table, { 'id' => { :type => 'int(1)', :extra => 'auto_increment' } })
+      @table.satisfies_id_autoincrement_requirement?.must_equal true
     end
 
-    it 'should not be satisfied with multicolumn primary key' do
-      @table = Lhm::Table.new('table', ['id', 'secondary'])
-      @table.satisfies_primary_key?.must_equal false
+    it 'should not be satisfied if id is not numeric' do
+      @table = Lhm::Table.new('table', 'id')
+      set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
+      @table.satisfies_id_autoincrement_requirement?.must_equal false
+    end
+
+    it 'should not be satisfied if id is not auto increment' do
+      @table = Lhm::Table.new('table', 'id')
+      set_columns(@table, { 'id' => { :type => 'int(1)' } })
+      @table.satisfies_id_autoincrement_requirement?.must_equal false
     end
   end
 end


### PR DESCRIPTION
The `Chunker` requires an auto incrementing integer column called `id`
to successfully chunk the table while migrating.