### PR TITLE
Making sure that LHM will retry the atomic switch on lock wait timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # 3.0.0
 
-* #63 - Sets the LHM's session lock wait timeout variables (Camilo)
-* #75 - Remove DataMapper and ActiveRecord 2.x support (Camilo)
+* #93 - Makes the atomic switcher retry on metadata locks (@camilo)
+* #63 - Sets the LHM's session lock wait timeout variables (@camilo)
+* #75 - Remove DataMapper and ActiveRecord 2.x support (@camilo)
 
 # 2.2.0 (Jan 16, 2015)
 

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -13,14 +13,20 @@ module Lhm
   # Lhm::SqlHelper.supports_atomic_switch?.
   class AtomicSwitcher
     include Command
+    RETRY_SLEEP_TIME = 10
+    MAX_RETRIES = 600
 
-    attr_reader :connection
+    attr_reader :connection, :retries
+    attr_writer :max_retries, :retry_sleep_time
 
     def initialize(migration, connection = nil)
       @migration = migration
       @connection = connection
       @origin = migration.origin
       @destination = migration.destination
+      @retries = 0
+      @max_retries = MAX_RETRIES
+      @retry_sleep_time = RETRY_SLEEP_TIME
     end
 
     def statements
@@ -44,7 +50,21 @@ module Lhm
     private
 
     def execute
-      @connection.sql(statements)
+      begin
+        @connection.sql(statements)
+      rescue ActiveRecord::StatementInvalid => error
+        if should_retry_exception?(error) && (@retries += 1) < @max_retries
+          sleep(@retry_sleep_time)
+          Lhm.logger.warn "Retrying sql=#{statements} error=#{error} retries=#{@retries}"
+          retry
+        else
+          raise
+        end
+      end
+    end
+
+    def should_retry_exception?(error)
+      error.message =~ /Lock wait timeout exceeded/
     end
   end
 end

--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -64,7 +64,7 @@ module Lhm
     end
 
     def should_retry_exception?(error)
-      error.message =~ /Lock wait timeout exceeded/
+      defined?(Mysql2) &&  error.message =~ /Lock wait timeout exceeded/
     end
   end
 end

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -14,9 +14,90 @@ describe Lhm::AtomicSwitcher do
 
   describe 'switching' do
     before(:each) do
-      @origin      = table_create('origin')
-      @destination = table_create('destination')
+      @origin      = table_create("origin")
+      @destination = table_create("destination")
       @migration   = Lhm::Migration.new(@origin, @destination)
+      @connection.execute("SET GLOBAL innodb_lock_wait_timeout=3")
+      @connection.execute("SET GLOBAL lock_wait_timeout=3")
+    end
+
+   it "should retry on lock wait timeouts" do
+     without_verbose do
+       mutex = Mutex.new
+       cond = ConditionVariable.new
+
+       locking_thread = Thread.new do 
+         with_per_thread_lhm_connection do |conn|
+
+           conn.sql('BEGIN')
+           conn.sql("DELETE from #{@destination.name}")
+           mutex.synchronize { sleep(1); cond.signal }
+           sleep(10)
+           conn.sql('ROLLBACK')
+         end
+       end
+
+       switching_thread = Thread.new do
+         with_per_thread_lhm_connection do |conn|
+           switcher = Lhm::AtomicSwitcher.new(@migration, conn)
+           switcher.retry_sleep_time = 0.2
+           mutex.synchronize do
+             cond.wait(mutex)
+             switcher.run
+           end
+           Thread.current[:retries] = switcher.retries
+         end
+       end
+
+       switching_thread.join
+       assert switching_thread[:retries] > 0, "The switcher did not retry"
+     end
+   end
+
+   it "should give up on lock wait timeouts after MAX_RETRIES" do
+     without_verbose do
+       mutex = Mutex.new
+       cond = ConditionVariable.new
+
+       locking_thread = Thread.new do
+         with_per_thread_lhm_connection do |conn|
+
+           conn.sql('BEGIN')
+           conn.sql("DELETE from #{@destination.name}")
+           mutex.synchronize { sleep(1); cond.signal }
+           sleep(100)
+           conn.sql('ROLLBACK')
+         end
+       end
+
+       switching_thread = Thread.new do
+         with_per_thread_lhm_connection do |conn|
+           switcher = Lhm::AtomicSwitcher.new(@migration, conn)
+           switcher.max_retries = 2
+           switcher.retry_sleep_time = 0
+           mutex.synchronize do
+             cond.wait(mutex)
+             begin
+               switcher.run
+             rescue ActiveRecord::StatementInvalid => error
+               Thread.current[:exception] = error
+
+             end
+           end
+         end
+       end
+
+       switching_thread.join
+       assert switching_thread[:exception].is_a?(ActiveRecord::StatementInvalid)
+     end
+   end
+
+    it "should raise on non lock wait timeout exceptions" do
+      switcher = Lhm::AtomicSwitcher.new(@migration, connection)
+      switcher.send :define_singleton_method, :statements do 
+        ['SELECT', '*', 'FROM', 'nonexistent']
+      end
+      ->{ switcher.run }.must_raise(ActiveRecord::StatementInvalid)
     end
 
     it 'rename origin to archive' do

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -28,11 +28,10 @@ describe Lhm::AtomicSwitcher do
 
        locking_thread = Thread.new do 
          with_per_thread_lhm_connection do |conn|
-
            conn.sql('BEGIN')
            conn.sql("DELETE from #{@destination.name}")
-           mutex.synchronize { sleep(1); cond.signal }
-           sleep(10)
+           mutex.synchronize { cond.signal }
+           sleep(10)  # make sure to stop here and lock the other thread out
            conn.sql('ROLLBACK')
          end
        end
@@ -64,8 +63,8 @@ describe Lhm::AtomicSwitcher do
 
            conn.sql('BEGIN')
            conn.sql("DELETE from #{@destination.name}")
-           mutex.synchronize { sleep(1); cond.signal }
-           sleep(100)
+           mutex.synchronize { cond.signal }
+           sleep(100) # Sleep for log so LHM gives up
            conn.sql('ROLLBACK')
          end
        end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -147,6 +147,14 @@ module IntegrationHelper
     >)
   end
 
+  def with_per_thread_lhm_connection
+    pool = ActiveRecord::Base.establish_connection(adapter: 'mysql2', database: 'lhm')
+    pool.with_connection do |conn|
+      lhm_connection = Lhm::Connection.new(conn)
+      yield  lhm_connection
+    end
+  end
+
   #
   # Environment
   #

--- a/spec/integration/locked_switcher_spec.rb
+++ b/spec/integration/locked_switcher_spec.rb
@@ -10,7 +10,15 @@ require 'lhm/locked_switcher'
 describe Lhm::LockedSwitcher do
   include IntegrationHelper
 
-  before(:each) { connect_master! }
+  before(:each) do
+    connect_master!
+    @old_logger = Lhm.logger
+    Lhm.logger = Logger.new('/dev/null')
+  end
+
+  after(:each) do
+    Lhm.logger = @old_logger
+  end
 
   describe 'switching' do
     before(:each) do

--- a/spec/test_helper.rb
+++ b/spec/test_helper.rb
@@ -21,3 +21,10 @@ end
 logger = Logger.new STDOUT
 logger.level = Logger::WARN
 Lhm.logger = logger
+
+def without_verbose(&block)
+  old_verbose, $VERBOSE = $VERBOSE, nil
+  yield
+ensure
+  $VERBOSE = old_verbose
+end


### PR DESCRIPTION
## Problem

If the metadata lock is taken a LHM will fail with  lock wait timeout

## Solution

Sleep one second and retry until we succeed or reach  `MAX_RETRIES`.

This is a patch already merged and used in Shopify/lhm

@arthurnn  @jasonhl 

