### PR TITLE
Pass the locking query instead of relying on some ivar

### DIFF
--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -33,7 +33,7 @@ describe Lhm::AtomicSwitcher do
      without_verbose do
        queue = Queue.new
 
-       locking_thread = start_locking_thread(10, queue)
+       locking_thread = start_locking_thread(10, queue, "DELETE from #{@destination.name}")
 
        switching_thread = Thread.new do
          conn = ar_conn 3306
@@ -55,7 +55,7 @@ describe Lhm::AtomicSwitcher do
 
      without_verbose do
        queue = Queue.new
-       locking_thread = start_locking_thread(10, queue)
+       locking_thread = start_locking_thread(10, queue, "DELETE from #{@destination.name}")
 
        switching_thread = Thread.new do
          conn = ar_conn 3306

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -89,11 +89,11 @@ module IntegrationHelper
   end
 
   # Helps testing behaviour when another client locks the db
-  def start_locking_thread(lock_for, queue)
+  def start_locking_thread(lock_for, queue, locking_query)
     Thread.new do
       conn = Mysql2::Client.new(host: '127.0.0.1', database: 'lhm', user: 'root', port: 3306)
       conn.query('BEGIN')
-      conn.query("DELETE from #{@destination.name}")
+      conn.query(locking_query)
       queue.push(true)
       sleep(lock_for) # Sleep for log so LHM gives up
       conn.query('ROLLBACK')


### PR DESCRIPTION
This PR simply removes the dependency between a helper and an ivar in the spec proper

@arthurnn 