### PR TITLE
Slave lag throttler for upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ rvm:
   - 2.1
 sudo: false
 gemfile:
-  - gemfiles/ar-3.2_mysql.gemfile
-  - gemfiles/ar-3.2_mysql2.gemfile
   - gemfiles/ar-4.0_mysql2.gemfile
   - gemfiles/ar-4.1_mysql2.gemfile
   - gemfiles/ar-4.2_mysql2.gemfile

--- a/Rakefile
+++ b/Rakefile
@@ -6,14 +6,14 @@ Bundler::GemHelper.install_tasks
 Rake::TestTask.new('unit') do |t|
   t.libs << 'lib'
   t.libs << 'spec'
-  t.test_files = FileList['spec/unit/*_spec.rb']
+  t.test_files = FileList['spec/unit/**/*_spec.rb']
   t.verbose = true
 end
 
 Rake::TestTask.new('integration') do |t|
   t.libs << 'lib'
   t.libs << 'spec'
-  t.test_files = FileList['spec/integration/*_spec.rb']
+  t.test_files = FileList['spec/integration/**/*_spec.rb']
   t.verbose = true
 end
 

--- a/gemfiles/ar-3.2_mysql.gemfile
+++ b/gemfiles/ar-3.2_mysql.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "mysql", "~> 2.8.1"
-gem "activerecord", "~> 3.2.2"
-gemspec :path=>"../"

--- a/gemfiles/ar-3.2_mysql2.gemfile
+++ b/gemfiles/ar-3.2_mysql2.gemfile
@@ -1,5 +1,0 @@
-source "https://rubygems.org"
-
-gem "mysql2", "~> 0.3.11"
-gem "activerecord", "~> 3.2.2"
-gemspec :path=>"../"

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -63,7 +63,7 @@ module Lhm
       end
 
       if options[:throttler]
-        options[:throttler] = Throttler::Factory.create_throttler(*options[:throttler])
+        options[:throttler] = Throttler::Factory.create_throttler(*options[:throttler].merge({:connection => @connection}))
       elsif options[:throttle] || options[:stride]
         # we still support the throttle and stride as a Fixnum input
         warn 'throttle option will no longer accept a Fixnum in the next versions.'

--- a/lib/lhm/throttler.rb
+++ b/lib/lhm/throttler.rb
@@ -1,8 +1,9 @@
 require 'lhm/throttler/time'
+require 'lhm/throttler/slave_lag'
 
 module Lhm
   module Throttler
-    CLASSES = { :time_throttler => Throttler::Time }
+    CLASSES = { :time_throttler => Throttler::Time, :slave_lag_throttler => Throttler::SlaveLag }
 
     def throttler
       @throttler ||= Throttler::Time.new

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -53,13 +53,13 @@ module Lhm
         slaves = slave_hosts.map { |slave_host| slave_host.partition(":")[0] }
         slaves.delete_if { |slave| slave == "localhost" || slave == "127.0.0.1" }
       end
-   
+
       def get_slaves
         @connection.execute(SQL_SELECT_SLAVE_HOSTS).map(&:first)
-      end  
-  
+      end
+
       def max_current_slave_lag
-        slave_hosts.map { |slave| slave_lag(slave).max }.push(0).max
+        slave_hosts.map { |slave| slave_lag(slave) }.flatten.push(0).max
       end
 
       def slave_lag(slave)

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -1,0 +1,87 @@
+module Lhm
+  module Throttler
+    class SlaveLag 
+      include Command
+
+      DEFAULT_TIMEOUT = 0.1
+      DEFAULT_STRIDE = 40_000
+      DEFAULT_MAX_ALLOWED_LAG = 10
+
+      MAX_TIMEOUT = DEFAULT_TIMEOUT * 1024
+
+      attr_accessor :timeout_seconds
+      attr_accessor :stride
+      attr_accessor :allowed_lag
+
+      def initialize(options = {})
+        raise ArgumentError, "You must provide a valid :connection option when using the slave lag throttler" unless options[:connection]
+
+        @timeout_seconds = DEFAULT_TIMEOUT
+        @stride = options[:stride] || DEFAULT_STRIDE
+        @allowed_lag = options[:allowed_lag] || DEFAULT_MAX_ALLOWED_LAG
+        @connection = options[:connection]
+        @slave_connections = {}
+      end
+
+      def execute
+        sleep(throttle_seconds)
+      end
+
+      private
+
+      SQL_SELECT_SLAVE_HOSTS = "SELECT host FROM information_schema.processlist WHERE command='Binlog Dump'"
+      SQL_SELECT_MAX_SLAVE_LAG = "SHOW SLAVE STATUS"
+
+      private_constant :SQL_SELECT_SLAVE_HOSTS, :SQL_SELECT_MAX_SLAVE_LAG
+
+      def throttle_seconds
+        lag = max_current_slave_lag
+
+        if lag > @allowed_lag && @timeout_seconds < MAX_TIMEOUT
+          Lhm.logger.info("Increasing timeout between strides from #{@timeout_seconds} to #{@timeout_seconds * 2} because #{lag} seconds of slave lag detected is greater than the maximum of #{@allowed_lag} seconds allowed.")
+          @timeout_seconds = @timeout_seconds * 2 
+        elsif lag <= @allowed_lag && @timeout_seconds > DEFAULT_TIMEOUT
+          Lhm.logger.info("Decreasing timeout between strides from #{@timeout_seconds} to #{@timeout_seconds / 2} because #{lag} seconds of slave lag detected is less than or equal to the #{@allowed_lag} seconds allowed.")
+          @timeout_seconds = @timeout_seconds / 2
+        else
+          @timeout_seconds
+        end
+      end
+
+      def slave_hosts
+        slave_hosts = get_slaves
+        slaves = slave_hosts.map { |slave_host| slave_host.partition(":")[0] }
+        slaves.delete_if { |slave| slave == "localhost" || slave == "127.0.0.1" }
+      end
+   
+      def get_slaves
+        @connection.execute(SQL_SELECT_SLAVE_HOSTS).map(&:first)
+      end  
+  
+      def max_current_slave_lag
+        lags = [0]
+        slave_hosts.each do |slave|
+          lags.concat(slave_lag(slave))
+        end
+        lags.max
+      end
+
+      def slave_lag(slave)
+        lags = []
+        adapter_method = defined?(Mysql2) ? 'mysql2_connection' : 'mysql_connection'
+        config = { :host => slave,
+                   :port => ActiveRecord::Base.connection_config[:port],
+                   :username => ActiveRecord::Base.connection_config[:username],
+                   :password => ActiveRecord::Base.connection_config[:password], 
+                   :database => ActiveRecord::Base.connection_config[:database]
+                 }
+        conn = Lhm::Connection.new(ActiveRecord::Base.send(adapter_method, config))
+        result = conn.execute(SQL_SELECT_MAX_SLAVE_LAG)
+        result.each(:as => :hash) {|row| lags.push( row["Seconds_Behind_Master"].to_i ) }
+        lags
+      rescue Error
+        raise Lhm::Error, "Unable to connect and/or query slave to determine slave lag. Migration aborting."
+      end
+    end
+  end
+end

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -63,13 +63,13 @@ describe Lhm::Chunker do
       throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0, :connection => connection)
       def throttler.max_current_slave_lag
         1
-      end 
-      
+      end
+
       Lhm::Chunker.new(
         @migration, connection, { :throttler => throttler, :printer => printer }
       ).run
 
-      assert_equal(Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT * 2 * 2, throttler.timeout_seconds)      
+      assert_equal(Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT * 2 * 2, throttler.timeout_seconds)
 
       slave do
         count_all(@destination.name).must_equal(5)
@@ -96,7 +96,7 @@ describe Lhm::Chunker do
         @migration, connection, { :throttler => throttler, :printer => printer }
       ).run
 
-      assert_equal(Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT, throttler.timeout_seconds)
+      assert_equal(Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT, throttler.timeout_seconds)
       assert_equal(0, throttler.send(:max_current_slave_lag))
 
       slave do

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -86,21 +86,18 @@ describe Lhm::Chunker do
       printer.expect(:end, :return_value, [])
 
       throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0, :connection => connection)
-      slaves = throttler.send(:get_slaves).map { |slave_host| slave_host.partition(":")[0] }
-      assert_equal(["localhost"], slaves)
 
       def throttler.slave_hosts
         ["127.0.0.1"]
       end
 
-      ActiveRecord::Base.connection_config[:port] = "3307"
 
       Lhm::Chunker.new(
         @migration, connection, { :throttler => throttler, :printer => printer }
       ).run
 
-      assert_equal(Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT, throttler.timeout_seconds)      
-      assert_equal(0, throttler.send(:max_current_slave_lag))      
+      assert_equal(Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT, throttler.timeout_seconds)
+      assert_equal(0, throttler.send(:max_current_slave_lag))
 
       slave do
         count_all(@destination.name).must_equal(5)

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -17,7 +17,7 @@ describe Lhm::Chunker do
       @migration = Lhm::Migration.new(@origin, @destination)
     end
 
-    it 'should copy 23 rows from origin to destination' do
+    it 'should copy 23 rows from origin to destination with time based throttler' do
       23.times { |n| execute("insert into origin set id = '#{ n * n + 23 }'") }
 
       printer = MiniTest::Mock.new
@@ -30,6 +30,80 @@ describe Lhm::Chunker do
 
       slave do
         count_all(@destination.name).must_equal(23)
+      end
+
+      printer.verify
+    end
+
+    it 'should copy 23 rows from origin to destination with slave lag based throttler' do
+      23.times { |n| execute("insert into origin set id = '#{ n * n + 23 }'") }
+
+      printer = MiniTest::Mock.new
+      5.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
+      printer.expect(:end, :return_value, [])
+
+      Lhm::Chunker.new(
+        @migration, connection, { :throttler => Lhm::Throttler::SlaveLag.new(:stride => 100, :connection => connection), :printer => printer }
+      ).run
+
+      slave do
+        count_all(@destination.name).must_equal(23)
+      end
+
+      printer.verify
+    end
+
+    it 'should throttle work stride based on slave lag' do
+      5.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
+
+      printer = MiniTest::Mock.new
+      15.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
+      printer.expect(:end, :return_value, [])
+
+      throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0, :connection => connection)
+      def throttler.max_current_slave_lag
+        1
+      end 
+      
+      Lhm::Chunker.new(
+        @migration, connection, { :throttler => throttler, :printer => printer }
+      ).run
+
+      assert_equal(Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT * 2 * 2, throttler.timeout_seconds)      
+
+      slave do
+        count_all(@destination.name).must_equal(5)
+      end
+
+      printer.verify
+    end
+
+    it 'should detect a single slave with no lag in the default configuration' do
+      5.times { |n| execute("insert into origin set id = '#{ (n * n) + 1 }'") }
+
+      printer = MiniTest::Mock.new
+      15.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
+      printer.expect(:end, :return_value, [])
+
+      throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0, :connection => connection)
+      slaves = throttler.send(:get_slaves).map { |slave_host| slave_host.partition(":")[0] }
+      assert_equal(["localhost"], slaves)
+
+      def throttler.slave_hosts
+        ["127.0.0.1"]
+      end
+
+      ActiveRecord::Base.connection_config[:port] = "3307"
+
+      Lhm::Chunker.new(
+        @migration, connection, { :throttler => throttler, :printer => printer }
+      ).run
+
+      assert_equal(Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT, throttler.timeout_seconds)      
+      assert_equal(0, throttler.send(:max_current_slave_lag))      
+
+      slave do
+        count_all(@destination.name).must_equal(5)
       end
 
       printer.verify

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -59,9 +59,9 @@ describe Lhm::Throttler::SlaveLag do
       end
 
       it 'does not decrease the timeout past the minimum on repeated runs' do
-        @throttler.timeout_seconds = Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT * 2 
-        assert_equal(Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT, @throttler.send(:throttle_seconds))
-        assert_equal(Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT, @throttler.send(:throttle_seconds))
+        @throttler.timeout_seconds = Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT * 2 
+        assert_equal(Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT, @throttler.send(:throttle_seconds))
+        assert_equal(Lhm::Throttler::SlaveLag::INITIAL_TIMEOUT, @throttler.send(:throttle_seconds))
       end
     end
   end

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -6,7 +6,11 @@ describe Lhm::Throttler::SlaveLag do
   include UnitHelper
 
   before :each do
-    @throttler = Lhm::Throttler::SlaveLag.new(:connection => Class.new)
+    conn = Class.new do
+      def execute
+      end
+    end 
+    @throttler = Lhm::Throttler::SlaveLag.new(:connection => conn.new)
   end
 
   describe '#throttle_seconds' do

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -1,0 +1,102 @@
+require File.expand_path(File.dirname(__FILE__)) + '/../unit_helper'
+
+require 'lhm/throttler/slave_lag'
+
+describe Lhm::Throttler::SlaveLag do
+  include UnitHelper
+
+  before :each do
+    @throttler = Lhm::Throttler::SlaveLag.new(:connection => Class.new)
+  end
+
+  describe '#throttle_seconds' do
+    describe 'with no slave lag' do
+      before do
+        def @throttler.max_current_slave_lag
+          0
+        end
+      end
+
+      it 'does not alter the currently set timeout' do
+        timeout = @throttler.timeout_seconds
+        assert_equal(timeout, @throttler.send(:throttle_seconds))
+      end
+    end
+
+    describe 'with a large slave lag' do
+      before do
+        def @throttler.max_current_slave_lag
+          100
+        end
+      end
+
+      it 'doubles the currently set timeout' do
+        timeout = @throttler.timeout_seconds
+        assert_equal(timeout * 2, @throttler.send(:throttle_seconds))
+      end
+
+      it 'does not increase the timeout past the maximum' do
+        @throttler.timeout_seconds = Lhm::Throttler::SlaveLag::MAX_TIMEOUT
+        assert_equal(Lhm::Throttler::SlaveLag::MAX_TIMEOUT, @throttler.send(:throttle_seconds))
+      end
+    end
+
+    describe 'with no slave lag after it has previously been increased' do
+      before do
+        def @throttler.max_current_slave_lag
+          0
+        end
+      end
+
+      it 'halves the currently set timeout' do
+        @throttler.timeout_seconds *= 2 * 2
+        timeout = @throttler.timeout_seconds
+        assert_equal(timeout / 2, @throttler.send(:throttle_seconds))
+      end
+
+      it 'does not decrease the timeout past the minimum on repeated runs' do
+        @throttler.timeout_seconds = Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT * 2 
+        assert_equal(Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT, @throttler.send(:throttle_seconds))
+        assert_equal(Lhm::Throttler::SlaveLag::DEFAULT_TIMEOUT, @throttler.send(:throttle_seconds))
+      end
+    end
+  end
+
+  describe '#slave_hosts' do
+    describe 'with no slaves' do
+      before do
+        def @throttler.get_slaves
+          []
+        end
+      end
+
+      it 'returns no slave hosts' do
+        assert_equal([],@throttler.send(:slave_hosts)) 
+      end
+    end
+
+    describe 'with only localhost slaves' do
+      before do
+        def @throttler.get_slaves
+          ["localhost:1234", "127.0.0.1:5678"]
+        end
+      end
+
+      it 'returns no slave hosts' do
+        assert_equal([],@throttler.send(:slave_hosts)) 
+      end
+    end
+    
+    describe 'with only remote slaves' do
+      before do
+        def @throttler.get_slaves
+          ["server.example.com:1234", "anotherserver.example.com"]
+        end
+      end
+
+      it 'returns remote slave hosts' do
+        assert_equal(["server.example.com", "anotherserver.example.com"] ,@throttler.send(:slave_hosts)) 
+      end
+    end
+  end
+end

--- a/spec/unit/throttler_spec.rb
+++ b/spec/unit/throttler_spec.rb
@@ -12,7 +12,7 @@ describe Lhm::Throttler do
   end
 
   describe '#setup_throttler' do
-    describe 'when passing a key' do
+    describe 'when passing a time_throttler key' do
       before do
         @mock.setup_throttler(:time_throttler, :delay => 2)
       end
@@ -25,8 +25,22 @@ describe Lhm::Throttler do
         @mock.throttler.timeout_seconds.must_equal 2
       end
     end
+    
+    describe 'when passing a slave_lag_throttler key' do
+      before do
+        @mock.setup_throttler(:slave_lag_throttler, :allowed_lag => 20, :connection => Class.new)
+      end
 
-    describe 'when passing an instance' do
+      it 'instantiates the slave_lag throttle' do
+        @mock.throttler.class.must_equal Lhm::Throttler::SlaveLag
+      end
+
+      it 'returns 20 seconds as allowed_lag' do
+        @mock.throttler.allowed_lag.must_equal 20
+      end
+    end
+
+    describe 'when passing a time_throttler instance' do
 
       before do
         @instance = Class.new(Lhm::Throttler::Time) do
@@ -47,11 +61,43 @@ describe Lhm::Throttler do
       end
     end
 
-    describe 'when passing a class' do
+    describe 'when passing a slave_lag_throttler instance' do
+
+      before do
+        @instance = Lhm::Throttler::SlaveLag.new(:connection => Class.new)
+        def @instance.timeout_seconds
+          0
+        end
+
+        @mock.setup_throttler(@instance)
+      end
+
+      it 'returns the instace given' do
+        @mock.throttler.must_equal @instance
+      end
+
+      it 'returns 0 seconds as time' do
+        @mock.throttler.timeout_seconds.must_equal 0
+      end
+    end
+
+    describe 'when passing a time_throttler class' do
 
       before do
         @klass = Class.new(Lhm::Throttler::Time)
         @mock.setup_throttler(@klass)
+      end
+
+      it 'has the same class as given' do
+        @mock.throttler.class.must_equal @klass
+      end
+    end
+
+    describe 'when passing a slave_lag_throttler class' do
+
+      before do
+        @klass = Class.new(Lhm::Throttler::SlaveLag)
+        @mock.setup_throttler(@klass, :connection => Class.new)
       end
 
       it 'has the same class as given' do

--- a/spec/unit/throttler_spec.rb
+++ b/spec/unit/throttler_spec.rb
@@ -9,6 +9,11 @@ describe Lhm::Throttler do
     @mock = Class.new do
       extend Lhm::Throttler
     end
+
+    @conn = Class.new do
+      def execute
+      end
+    end
   end
 
   describe '#setup_throttler' do
@@ -28,7 +33,7 @@ describe Lhm::Throttler do
     
     describe 'when passing a slave_lag_throttler key' do
       before do
-        @mock.setup_throttler(:slave_lag_throttler, :allowed_lag => 20, :connection => Class.new)
+        @mock.setup_throttler(:slave_lag_throttler, :allowed_lag => 20, :connection => @conn.new)
       end
 
       it 'instantiates the slave_lag throttle' do
@@ -64,7 +69,7 @@ describe Lhm::Throttler do
     describe 'when passing a slave_lag_throttler instance' do
 
       before do
-        @instance = Lhm::Throttler::SlaveLag.new(:connection => Class.new)
+        @instance = Lhm::Throttler::SlaveLag.new(:connection => @conn.new)
         def @instance.timeout_seconds
           0
         end
@@ -97,7 +102,7 @@ describe Lhm::Throttler do
 
       before do
         @klass = Class.new(Lhm::Throttler::SlaveLag)
-        @mock.setup_throttler(@klass, :connection => Class.new)
+        @mock.setup_throttler(@klass, :connection => @conn.new)
       end
 
       it 'has the same class as given' do


### PR DESCRIPTION
This is the same as #1 but against upstream.

> An LHM throttler which tries to query any directly connected DB slaves, verifies their replication lag and adjusts the sleep period in between strides based on the amount of lag present. The sleep period will double each time the lag detected is greater than the desired threshold (up to a maximum).

@arthurnn , @jasonhl 