### PR TITLE
Make triggers configurable

### DIFF
--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -37,7 +37,7 @@ module Lhm
       set_session_lock_wait_timeouts
       migration = @migrator.run
 
-      Entangler.new(migration, @connection).run do
+      Entangler.new(migration, @connection, options).run do
         Chunker.new(migration, @connection, options).run
         if options[:atomic_switch]
           AtomicSwitcher.new(migration, @connection).run

--- a/spec/integration/entangler_spec.rb
+++ b/spec/integration/entangler_spec.rb
@@ -63,4 +63,56 @@ describe Lhm::Entangler do
       end
     end
   end
+
+  describe 'selective entanglement' do
+    before(:each) do
+      @origin = table_create('origin')
+      @destination = table_create('destination')
+      @migration = Lhm::Migration.new(@origin, @destination)
+      @entangler = Lhm::Entangler.new(@migration, connection, :triggers => [:insert])
+    end
+
+    it 'should replay inserts from origin into destination' do
+      @entangler.run do
+        execute("insert into origin (common) values ('inserted')")
+      end
+
+      slave do
+        count(:destination, 'common', 'inserted').must_equal(1)
+      end
+    end
+
+    it 'should not replay deletes from origin into destination' do
+      @entangler.run do
+        execute("insert into origin (common) values ('inserted')")
+        execute("delete from origin where common = 'inserted'")
+      end
+
+      slave do
+        count(:destination, 'common', 'inserted').must_equal(1)
+      end
+    end
+
+    it 'should not replay updates from origin into destination' do
+      @entangler.run do
+        execute("insert into origin (common) values ('inserted')")
+        execute("update origin set common = 'updated'")
+      end
+
+      slave do
+        count(:destination, 'common', 'updated').must_equal(0)
+      end
+    end
+
+    it 'should remove entanglement' do
+      @entangler.run {}
+
+      execute("insert into origin (common) values ('inserted')")
+
+      slave do
+        count(:destination, 'common', 'inserted').must_equal(0)
+      end
+    end
+  end
+
 end

--- a/spec/unit/entangler_spec.rb
+++ b/spec/unit/entangler_spec.rb
@@ -17,6 +17,33 @@ describe Lhm::Entangler do
     @entangler = Lhm::Entangler.new(@migration)
   end
 
+  let(:insert_ddl) {
+    %Q{
+        create trigger `lhmt_ins_origin`
+        after insert on `origin` for each row
+        replace into `destination` (`info`, `tags`) /* large hadron migration */
+        values (`NEW`.`info`, `NEW`.`tags`)
+      }
+  }
+
+  let(:update_ddl) {
+    %Q{
+      create trigger `lhmt_upd_origin`
+      after update on `origin` for each row
+      replace into `destination` (`info`, `tags`) /* large hadron migration */
+      values (`NEW`.`info`, `NEW`.`tags`)
+    }
+  }
+
+  let(:delete_ddl) {
+    %Q{
+      create trigger `lhmt_del_origin`
+      after delete on `origin` for each row
+      delete ignore from `destination` /* large hadron migration */
+      where `destination`.`id` = OLD.`id`
+    }
+  }
+
   describe 'activation' do
     before(:each) do
       @origin.columns['info'] = { :type => 'varchar(255)' }
@@ -27,36 +54,15 @@ describe Lhm::Entangler do
     end
 
     it 'should create insert trigger to destination table' do
-      ddl = %Q{
-        create trigger `lhmt_ins_origin`
-        after insert on `origin` for each row
-        replace into `destination` (`info`, `tags`) /* large hadron migration */
-        values (`NEW`.`info`, `NEW`.`tags`)
-      }
-
-      @entangler.entangle.must_include strip(ddl)
+      @entangler.entangle.must_include strip(insert_ddl)
     end
 
     it 'should create an update trigger to the destination table' do
-      ddl = %Q{
-        create trigger `lhmt_upd_origin`
-        after update on `origin` for each row
-        replace into `destination` (`info`, `tags`) /* large hadron migration */
-        values (`NEW`.`info`, `NEW`.`tags`)
-      }
-
-      @entangler.entangle.must_include strip(ddl)
+      @entangler.entangle.must_include strip(update_ddl)
     end
 
     it 'should create a delete trigger to the destination table' do
-      ddl = %Q{
-        create trigger `lhmt_del_origin`
-        after delete on `origin` for each row
-        delete ignore from `destination` /* large hadron migration */
-        where `destination`.`id` = OLD.`id`
-      }
-
-      @entangler.entangle.must_include strip(ddl)
+      @entangler.entangle.must_include strip(delete_ddl)
     end
   end
 
@@ -73,4 +79,41 @@ describe Lhm::Entangler do
       @entangler.untangle.must_include('drop trigger if exists `lhmt_del_origin`')
     end
   end
+
+  describe 'selective entangle' do
+    before(:each) do
+      @entangler = Lhm::Entangler.new(@migration, nil, :triggers => [:update])
+
+      @origin.columns['info'] = { :type => 'varchar(255)' }
+      @origin.columns['tags'] = { :type => 'varchar(255)' }
+
+      @destination.columns['info'] = { :type => 'varchar(255)' }
+      @destination.columns['tags'] = { :type => 'varchar(255)' }
+    end
+
+    it 'should create update trigger to destination table' do
+      @entangler.entangle.must_include strip(update_ddl)
+    end
+
+    it 'should not create insert trigger to destination table' do
+      @entangler.entangle.wont_include strip(insert_ddl)
+    end
+
+    it 'should not create delete trigger to destination table' do
+      @entangler.entangle.wont_include strip(delete_ddl)
+    end
+
+    it 'should remove update trigger' do
+      @entangler.untangle.must_include('drop trigger if exists `lhmt_upd_origin`')
+    end
+
+    it 'should not remove insert trigger' do
+      @entangler.untangle.wont_include('drop trigger if exists `lhmt_ins_origin`')
+    end
+
+    it 'should not remove delete trigger' do
+      @entangler.untangle.wont_include('drop trigger if exists `lhmt_del_origin`')
+    end
+  end
+
 end


### PR DESCRIPTION
Make the triggers that are used configurable for cases where you don't
care about a particular type of operation being replicated.
