### PR TITLE
Inject connection into throttler

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -16,7 +16,9 @@ module Lhm
     def initialize(migration, connection = nil, options = {})
       @migration = migration
       @connection = connection
-      @throttler = options[:throttler]
+      if @throttler = options[:throttler]
+        @throttler.connection = @connection if @throttler.respond_to?(:connection=)
+      end
       @start = options[:start] || select_start
       @limit = options[:limit] || select_limit
       @printer = options[:printer] || Printer::Percentage.new

--- a/lib/lhm/throttler/slave_lag.rb
+++ b/lib/lhm/throttler/slave_lag.rb
@@ -9,17 +9,12 @@ module Lhm
 
       MAX_TIMEOUT = INITIAL_TIMEOUT * 1024
 
-      attr_accessor :timeout_seconds
-      attr_accessor :stride
-      attr_accessor :allowed_lag
+      attr_accessor :timeout_seconds, :allowed_lag, :stride, :connection
 
       def initialize(options = {})
-        raise ArgumentError, 'You must provide a valid :connection option when using the slave lag throttler' unless options[:connection] && options[:connection].respond_to?(:execute)
-
         @timeout_seconds = INITIAL_TIMEOUT
         @stride = options[:stride] || DEFAULT_STRIDE
         @allowed_lag = options[:allowed_lag] || DEFAULT_MAX_ALLOWED_LAG
-        @connection = options[:connection]
         @slave_connections = {}
       end
 

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -43,7 +43,7 @@ describe Lhm::Chunker do
       printer.expect(:end, :return_value, [])
 
       Lhm::Chunker.new(
-        @migration, connection, { :throttler => Lhm::Throttler::SlaveLag.new(:stride => 100, :connection => connection), :printer => printer }
+        @migration, connection, { :throttler => Lhm::Throttler::SlaveLag.new(:stride => 100), :printer => printer }
       ).run
 
       slave do
@@ -60,7 +60,7 @@ describe Lhm::Chunker do
       15.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
       printer.expect(:end, :return_value, [])
 
-      throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0, :connection => connection)
+      throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0)
       def throttler.max_current_slave_lag
         1
       end
@@ -85,7 +85,7 @@ describe Lhm::Chunker do
       15.times { printer.expect(:notify, :return_value, [Fixnum, Fixnum]) }
       printer.expect(:end, :return_value, [])
 
-      throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0, :connection => connection)
+      throttler = Lhm::Throttler::SlaveLag.new(:stride => 10, :allowed_lag => 0)
 
       def throttler.slave_hosts
         ['127.0.0.1']

--- a/spec/unit/throttler/slave_lag_spec.rb
+++ b/spec/unit/throttler/slave_lag_spec.rb
@@ -6,11 +6,7 @@ describe Lhm::Throttler::SlaveLag do
   include UnitHelper
 
   before :each do
-    conn = Class.new do
-      def execute
-      end
-    end
-    @throttler = Lhm::Throttler::SlaveLag.new(:connection => conn.new)
+    @throttler = Lhm::Throttler::SlaveLag.new
   end
 
   describe '#throttle_seconds' do

--- a/spec/unit/throttler_spec.rb
+++ b/spec/unit/throttler_spec.rb
@@ -33,7 +33,7 @@ describe Lhm::Throttler do
 
     describe 'when passing a slave_lag_throttler key' do
       before do
-        @mock.setup_throttler(:slave_lag_throttler, allowed_lag: 20, connection: @conn.new)
+        @mock.setup_throttler(:slave_lag_throttler, allowed_lag: 20)
       end
 
       it 'instantiates the slave_lag throttle' do
@@ -69,7 +69,7 @@ describe Lhm::Throttler do
     describe 'when passing a slave_lag_throttler instance' do
 
       before do
-        @instance = Lhm::Throttler::SlaveLag.new(connection: @conn.new)
+        @instance = Lhm::Throttler::SlaveLag.new
         def @instance.timeout_seconds
           0
         end
@@ -102,7 +102,7 @@ describe Lhm::Throttler do
 
       before do
         @klass = Class.new(Lhm::Throttler::SlaveLag)
-        @mock.setup_throttler(@klass, connection: @conn.new)
+        @mock.setup_throttler(@klass)
       end
 
       it 'has the same class as given' do


### PR DESCRIPTION
It is hard to access to connection globally. At the moment to setup a
global throttler that depends on the connection we need to pass it a
initialization time, which is not handy.
We can instead inject the connection at the time we are running the throttler.

review @camilo @jasonhl
cc @sroysen