### PR TITLE
Fixes intializing of Throttler factory

### DIFF
--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -68,7 +68,7 @@ module Lhm
       end
 
       if options[:throttler]
-        options[:throttler] = Throttler::Factory.create_throttler(*options[:throttler].merge(connection: @connection))
+        options[:throttler] = Throttler::Factory.create_throttler(options[:throttler], connection: @connection)
       else
         options[:throttler] = Lhm.throttler
       end


### PR DESCRIPTION
The call to the Throttler factory had the wrong arguments which was causing it to fail. This should fix that by calling with the correct arguments.

@camilo @arthurnn @jasonhl 

