### PR TITLE
Add license information to lhm.gemspec

### DIFF
--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -8,6 +8,7 @@ require 'lhm/version'
 Gem::Specification.new do |s|
   s.name          = 'lhm'
   s.version       = Lhm::VERSION
+  s.licenses      = ['New BSD']
   s.platform      = Gem::Platform::RUBY
   s.authors       = ['SoundCloud', 'Rany Keddo', 'Tobias Bielohlawek', 'Tobias Schmidt']
   s.email         = %q{rany@soundcloud.com, tobi@soundcloud.com, ts@soundcloud.com}

--- a/lhm.gemspec
+++ b/lhm.gemspec
@@ -8,7 +8,7 @@ require 'lhm/version'
 Gem::Specification.new do |s|
   s.name          = 'lhm'
   s.version       = Lhm::VERSION
-  s.licenses      = ['New BSD']
+  s.licenses      = ['BSD-3-Clause']
   s.platform      = Gem::Platform::RUBY
   s.authors       = ['SoundCloud', 'Rany Keddo', 'Tobias Bielohlawek', 'Tobias Schmidt']
   s.email         = %q{rany@soundcloud.com, tobi@soundcloud.com, ts@soundcloud.com}


### PR DESCRIPTION
Set the license to New BSD since the current LICENSE file looks like New BSD.

This allows tools like [License Finder](https://github.com/pivotal/LicenseFinder) to look up this project's metadata.

This also fixes the license display at https://rubygems.org/gems/lhm since it currently says 'N/A':
![image](https://cloud.githubusercontent.com/assets/289331/7599802/c6a9a7ac-f8ca-11e4-87b1-7d95ff79f5ab.png)