### PR TITLE
Update chunker requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Lhm.change_table :users, throttler: [:time_throttler, {stride: x}] do
 end
 ```
+* #114 - Update chunker requirements (@bjk-soundcloud)
 * #98 - Add slave lag throttler. (@camilo, @jasonhl)
 * #92 - Fix check for table requirement before starting a lhm.(@hannestyden)
 * #93 - Makes the atomic switcher retry on metadata locks (@camilo)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ ActiveRecord 3.2.x and 4.x (mysql and mysql2 adapters).
 ## Limitations
 
 Due to the Chunker implementation, Lhm requires that the table to migrate has a
-a monotonically increasing numeric key column called `id`.
+a single integer numeric key column called `id`.
+
+Another note about the Chunker, it performs static sized row copies against the `id`
+column.  Therefore sparse assignment of `id` can cause performance problems for the
+backfills.  Typically LHM assumes that `id` is an `auto_increment` style column.
 
 ## Installation
 

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -187,8 +187,8 @@ module Lhm
         error("could not find origin table #{ @origin.name }")
       end
 
-      unless @origin.satisfies_id_autoincrement_requirement?
-        error('origin does not satisfy primary key requirements')
+      unless @origin.satisfies_id_column_requirement?
+        error('origin does not satisfy `id` key requirements')
       end
 
       dest = @origin.destination_name

--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -15,10 +15,9 @@ module Lhm
       @ddl = ddl
     end
 
-    def satisfies_id_autoincrement_requirement?
+    def satisfies_id_column_requirement?
       !!((id = columns['id']) &&
-        id[:extra] == 'auto_increment' &&
-        id[:type] =~ /int\(\d+\)/)
+        id[:type] =~ /(bigint|int)\(\d+\)/)
     end
 
     def destination_name
@@ -54,13 +53,11 @@ module Lhm
             column_type    = struct_key(defn, 'COLUMN_TYPE')
             is_nullable    = struct_key(defn, 'IS_NULLABLE')
             column_default = struct_key(defn, 'COLUMN_DEFAULT')
-            extra          = struct_key(defn, 'EXTRA')
 
             table.columns[defn[column_name]] = {
               :type => defn[column_type],
               :is_nullable => defn[is_nullable],
               :column_default => defn[column_default],
-              :extra => defn[extra]
             }
           end
 

--- a/spec/fixtures/bigint_table.ddl
+++ b/spec/fixtures/bigint_table.ddl
@@ -1,0 +1,4 @@
+CREATE TABLE `bigint_table` (
+  `id` BIGINT(20) auto_increment,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/wo_id_int_column.ddl
+++ b/spec/fixtures/wo_id_int_column.ddl
@@ -1,0 +1,6 @@
+-- Without id int column
+CREATE TABLE `wo_id_int_column` (
+  `id` varchar(15) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8
+

--- a/spec/fixtures/wo_mon_inc_num.ddl
+++ b/spec/fixtures/wo_mon_inc_num.ddl
@@ -1,7 +1,0 @@
--- Without auto increment
-CREATE TABLE `wo_mon_inc_num` (
-  `id` int(11) NOT NULL,
-  `pk` varchar(255),
-  PRIMARY KEY (`pk`),
-  UNIQUE KEY `index_custom_primary_key_on_id` (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -8,7 +8,7 @@ describe Lhm do
 
   before(:each) { connect_master!; Lhm.cleanup(true) }
 
-  describe 'auto increment column requirement' do
+  describe 'id column requirement' do
     it 'should migrate the table when id is pk' do
       table_create(:users)
 
@@ -21,7 +21,6 @@ describe Lhm do
           :type           => 'int(12)',
           :is_nullable    => 'YES',
           :column_default => '0',
-          :extra          => ''
         })
       end
     end
@@ -38,18 +37,7 @@ describe Lhm do
           :type           => 'int(12)',
           :is_nullable    => 'YES',
           :column_default => '0',
-          :extra          => ''
         })
-      end
-    end
-
-    it 'should not migrate the id column is not auto increment' do
-      table_create(:wo_mon_inc_num)
-
-      assert_raises Lhm::Error do
-        Lhm.change_table(:wo_mon_inc_num, :atomic_switch => false) do |t|
-          t.add_column(:logins, "int(12) default '0'")
-        end
       end
     end
   end
@@ -109,7 +97,6 @@ describe Lhm do
           :type => 'int(12)',
           :is_nullable => 'YES',
           :column_default => '0',
-          :extra => ''
         })
       end
     end
@@ -216,7 +203,6 @@ describe Lhm do
           :type => 'tinyint(1)',
           :is_nullable => 'YES',
           :column_default => nil,
-          :extra => ''
         })
       end
     end
@@ -231,7 +217,6 @@ describe Lhm do
           :type => 'varchar(20)',
           :is_nullable => 'NO',
           :column_default => 'none',
-          :extra => ''
         })
       end
     end
@@ -248,7 +233,6 @@ describe Lhm do
           :type => 'int(5)',
           :is_nullable => 'NO',
           :column_default => '0',
-          :extra => ''
         })
       end
     end
@@ -268,7 +252,6 @@ describe Lhm do
           :type => 'varchar(255)',
           :is_nullable => 'YES',
           :column_default => nil,
-          :extra => ''
         })
 
         result = select_one('SELECT login from users')
@@ -292,7 +275,6 @@ describe Lhm do
           :type => 'varchar(255)',
           :is_nullable => 'YES',
           :column_default => 'Superfriends',
-          :extra => ''
         })
 
         result = select_one('SELECT `fnord` from users')

--- a/spec/integration/table_spec.rb
+++ b/spec/integration/table_spec.rb
@@ -7,7 +7,7 @@ require 'lhm/table'
 describe Lhm::Table do
   include IntegrationHelper
 
-  describe 'monotonically increasing numeric column requirement' do
+  describe 'id numeric column requirement' do
     describe 'when met' do
       before(:each) do
         connect_master!
@@ -26,16 +26,17 @@ describe Lhm::Table do
 
       it 'should parse columns' do
         @table.
-          columns['id'][:extra].
-          must_equal('auto_increment')
-
-        @table.
           columns['id'][:type].
-          must_match(/int\(\d+\)/)
+          must_match(/(bigint|int)\(\d+\)/)
       end
 
       it 'should return true for method that should be renamed' do
-        @table.satisfies_id_autoincrement_requirement?.must_equal true
+        @table.satisfies_id_column_requirement?.must_equal true
+      end
+
+      it 'should support bigint tables' do
+        @table = table_create(:bigint_table)
+        @table.satisfies_id_column_requirement?.must_equal true
       end
     end
 
@@ -44,9 +45,9 @@ describe Lhm::Table do
         connect_master!
       end
 
-      it 'should return false for method that should be renamed' do
-        @table = table_create(:wo_mon_inc_num)
-        @table.satisfies_id_autoincrement_requirement?.must_equal false
+      it 'should return false for a non-int id column' do
+        @table = table_create(:wo_id_int_column)
+        @table.satisfies_id_column_requirement?.must_equal false
       end
     end
   end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -22,26 +22,20 @@ describe Lhm::Table do
 
     it 'should be satisfied with a single column primary key called id' do
       @table = Lhm::Table.new('table', 'id')
-      set_columns(@table, { 'id' => { :type => 'int(1)', :extra => 'auto_increment' } })
-      @table.satisfies_id_autoincrement_requirement?.must_equal true
+      set_columns(@table, { 'id' => { :type => 'int(1)' } })
+      @table.satisfies_id_column_requirement?.must_equal true
     end
 
     it 'should be satisfied with a primary key not called id, as long as there is still an id' do
       @table = Lhm::Table.new('table', 'uuid')
-      set_columns(@table, { 'id' => { :type => 'int(1)', :extra => 'auto_increment' } })
-      @table.satisfies_id_autoincrement_requirement?.must_equal true
+      set_columns(@table, { 'id' => { :type => 'int(1)' } })
+      @table.satisfies_id_column_requirement?.must_equal true
     end
 
     it 'should not be satisfied if id is not numeric' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
-      @table.satisfies_id_autoincrement_requirement?.must_equal false
-    end
-
-    it 'should not be satisfied if id is not auto increment' do
-      @table = Lhm::Table.new('table', 'id')
-      set_columns(@table, { 'id' => { :type => 'int(1)' } })
-      @table.satisfies_id_autoincrement_requirement?.must_equal false
+      @table.satisfies_id_column_requirement?.must_equal false
     end
   end
 end


### PR DESCRIPTION
The chunker does not require an auto_increment column, it simply
requires an integer column in order to find the start/limit of the
table.

Relax the migrator/table checks to only look for an `id` INT column.
* Add support for BIGINT `id` columns
* Add fixture for BIGINT `id` column
* Add fixture for "broken" varchar `id` column
* Update specs