### PR TITLE
Don't ignore errors when copying data

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -52,7 +52,7 @@ module Lhm
     end
 
     def copy(lowest, highest)
-      "insert ignore into `#{ destination_name }` (#{ destination_columns }) " \
+      "insert into `#{ destination_name }` (#{ destination_columns }) " \
       "select #{ origin_columns } from `#{ origin_name }` " \
       "#{ conditions } `#{ origin_name }`.`id` between #{ lowest } and #{ highest }"
     end


### PR DESCRIPTION
When copying data to the new table we're using `INSERT IGNORE INTO ...`

From the [MySQL documentation](https://dev.mysql.com/doc/refman/5.1/en/insert.html):
> If you use the IGNORE keyword, errors that occur while executing the INSERT statement are ignored. For example, without IGNORE, a row that duplicates an existing UNIQUE index or PRIMARY KEY value in the table causes a duplicate-key error and the statement is aborted. With IGNORE, the row is discarded and no error occurs. Ignored errors may generate warnings instead, although duplicate-key errors do not.

Silently dropping rows of production data should be avoided at all cost. Instead let's fail the migration by raising an error. This allows another path to be taken towards the desired DB schema without the stress of restoring from DB backups! 