### PR TITLE
Improve compatibility of resulting schema

### DIFF
--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -88,7 +88,7 @@ module Lhm
       def extract_indices(indices)
         indices.
           map do |row|
-            key_name = struct_key(row, 'Key_name')
+            key_name = 'lhma_' + struct_key(row, 'Key_name')
             column_name = struct_key(row, 'COLUMN_NAME')
             [row[key_name], row[column_name]]
           end.


### PR DESCRIPTION
SQLite 3 have global namespace for indexes. Basically that means you can't have two indexes with a same name. This is resulting in conflicts when developer tries to create SQLite database from schema for local tests or CI.