### PR TITLE
Don't choke on lhmn_* in cleanup with range

### DIFF
--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -59,9 +59,11 @@ module Lhm
   def cleanup(run = false, options = {})
     lhm_tables = connection.select_values('show tables').select { |name| name =~ /^lhm(a|n)_/ }
     if options[:until]
-      lhm_tables.select! do |table|
-        table_date_time = Time.strptime(table, 'lhma_%Y_%m_%d_%H_%M_%S')
-        table_date_time <= options[:until]
+      lhm_tables.reject! do |table|
+        if table =~ /^lhma_/
+          table_date_time = Time.strptime(table, 'lhma_%Y_%m_%d_%H_%M_%S')
+          table_date_time > options[:until]
+        end
       end
     end
 


### PR DESCRIPTION
When running an Lhm.cleanup with a range it tries to strptime every table name, but if there are unswitched new tables then it fails:

```
 > Lhm.cleanup(false)

 Existing LHM backup tables: lhmn_statement_lines.
 Existing LHM triggers: .
 Run Lhm.cleanup(true) to drop them all.

 > Lhm.cleanup(true, until: 1.week.ago)

 ...:in `eval': invalid strptime format - `lhma_%Y_%m_%d_%H_%M_%S' (ArgumentError)
    from .../lhm-2.2.0/lib/lhm.rb:64:in `block in cleanup'
    from .../lhm-2.2.0/lib/lhm.rb:63:in `select!'
    from .../lhm-2.2.0/lib/lhm.rb:63:in `cleanup'
```

This patch includes the table in cleanup over a time range. We can't really date this table, so can't apply the range logic, but it should just be duplicated data in the table so should be safe to delete.
