### PR TITLE
Truncate long trigger names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Lhm.change_table :users, throttler: [:time_throttler, {stride: x}] do
 end
 ```
+* #118 - Truncate long trigger names. (@sj26)
 * #114 - Update chunker requirements (@bjk-soundcloud)
 * #98 - Add slave lag throttler. (@camilo, @jasonhl)
 * #92 - Fix check for table requirement before starting a lhm.(@hannestyden)

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -64,7 +64,7 @@ module Lhm
     end
 
     def trigger(type)
-      "lhmt_#{ type }_#{ @origin.name }"
+      "lhmt_#{ type }_#{ @origin.name }"[0...64]
     end
 
     def validate

--- a/spec/unit/entangler_spec.rb
+++ b/spec/unit/entangler_spec.rb
@@ -58,6 +58,21 @@ describe Lhm::Entangler do
 
       @entangler.entangle.must_include strip(ddl)
     end
+
+    describe 'super long table names' do
+      before(:each) do
+        @origin = Lhm::Table.new('a' * 64)
+        @destination = Lhm::Table.new('b' * 64)
+        @migration = Lhm::Migration.new(@origin, @destination)
+        @entangler = Lhm::Entangler.new(@migration)
+      end
+
+      it 'should use truncated names' do
+        @entangler.trigger(:ins).length.must_be :<=, 64
+        @entangler.trigger(:upd).length.must_be :<=, 64
+        @entangler.trigger(:del).length.must_be :<=, 64
+      end
+    end
   end
 
   describe 'removal' do


### PR DESCRIPTION
We are seeing:

    ==  SomeHorriblyLongMigrationInvolvingTablesWithNamesFarTooLongForHumanBeingsToConsiderReasonable: migrating
    I, [2015-07-15T12:07:08.972714 #47706]  INFO -- : Starting LHM run on table=lhmn_tables_with_names_far_too_long_for_human_beings_to_consider
    I, [2015-07-15T12:07:08.972868 #47706]  INFO -- : Starting run of class=Lhm::Migrator
    I, [2015-07-15T12:07:09.012700 #47706]  INFO -- : Starting run of class=Lhm::Entangler
    E, [2015-07-15T12:07:09.015775 #47706] ERROR -- : Error in class=Lhm::Entangler, reverting. exception=ActiveRecord::StatementInvalid message=Mysql2::Error: Identifier name 'lhmt_del_tables_with_names_far_too_long_for_human_beings_to_consider_reasonable' is too long: create trigger `lhmt_del_tables_with_names_far_too_long_for_human_beings_to_consider_reasonable`
    ...

It looks like this has already been faced in the migrator:

    def archive_name
      "lhma_#{ startstamp }_#{ @origin.name }"[0...64]
    end

So let's truncate here as well.