### PR TITLE
Fixed an incompatibility issue with the jdbcmysql adapter that's used for JRuby apps

### DIFF
--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -40,7 +40,7 @@ module Lhm
       def ddl
         sql = "show create table `#{ @table_name }`"
         specification = nil
-        @connection.execute(sql).each { |row| specification = row.last }
+        @connection.execute(sql).each { |row| specification = specification(row) }
         specification
       end
 
@@ -110,6 +110,14 @@ module Lhm
         end
 
         keys.length == 1 ? keys.first : keys
+      end
+
+      def specification(row)
+        if row.is_a?(Array)
+          row.last
+        else
+          row["Create Table"]
+        end
       end
     end
   end


### PR DESCRIPTION
the mysql2 gem returns an Array but the activerecord-jdbcmysql-adapter
uses a hash that looks like this:
{"Table"=>"servers", "Create Table"=>"CREATE TABLE `servers`}

without this fix the following exception is raised:
```
StandardError: An error has occurred, all later migrations canceled:

undefined method `last' for #<Hash:0xaba4a33>/Users/andrei/.rvm/gems/jruby-1.7.20/bundler/gems/lhm-8d6e8fdfa3b2/lib/lhm/table.rb:43:in `ddl'
/Users/andrei/.rvm/gems/jruby-1.7.20/bundler/gems/lhm-8d6e8fdfa3b2/lib/lhm/table.rb:43:in `ddl'
/Users/andrei/.rvm/gems/jruby-1.7.20/bundler/gems/lhm-8d6e8fdfa3b2/lib/lhm/table.rb:50:in `parse'
/Users/andrei/.rvm/gems/jruby-1.7.20/bundler/gems/lhm-8d6e8fdfa3b2/lib/lhm/table.rb:28:in `parse'
/Users/andrei/.rvm/gems/jruby-1.7.20/bundler/gems/lhm-8d6e8fdfa3b2/lib/lhm.rb:46:in `change_table'
/Users/andrei/projects/cloudstats/db/migrate/20151027094647_add_more_counters_to_server.rb:5:in `up'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:370:in `up'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:410:in `migrate'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:410:in `migrate'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/connection_adapters/abstract/connection_pool.rb:129:in `with_connection'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:389:in `migrate'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:528:in `migrate'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:720:in `migrate'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:777:in `ddl_transaction'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:719:in `migrate'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:700:in `migrate'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:570:in `up'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/migration.rb:551:in `migrate'
/Users/andrei/.rvm/gems/jruby-1.7.20/gems/activerecord-3.2.22/lib/active_record/railties/databases.rake:193:in `(root)'
```

This issue affects both the 3.0 and 2.2 versions