### PR TITLE
Adding failing test and fix for potential data destruction

### DIFF
--- a/lib/lhm/chunker.rb
+++ b/lib/lhm/chunker.rb
@@ -27,7 +27,7 @@ module Lhm
     def execute
       return unless @start && @limit
       @next_to_insert = @start
-      while @next_to_insert < @limit || (@next_to_insert == 1 && @start == 1)
+      while @next_to_insert < @limit || (@start == @limit)
         stride = @throttler.stride
         affected_rows = @connection.update(copy(bottom, top(stride)))
 
@@ -37,6 +37,7 @@ module Lhm
 
         @printer.notify(bottom, @limit)
         @next_to_insert = top(stride) + 1
+        break if @start == @limit
       end
       @printer.end
     end

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -17,7 +17,19 @@ describe Lhm::Chunker do
       @migration = Lhm::Migration.new(@origin, @destination)
     end
 
-    it 'should copy 23 rows from origin to destination with time based throttler' do
+    it 'should copy 1  rows from origin to destination even if the id of the single row does not start at 1' do
+      execute("insert into origin set id = 1001 ")
+
+      Lhm::Chunker.new(@migration, connection, {}).run
+
+      slave do
+        count_all(@destination.name).must_equal(1)
+      end
+
+      printer.verify
+    end
+
+    it 'should copy 23 rows from origin to destination' do
       23.times { |n| execute("insert into origin set id = '#{ n * n + 23 }'") }
 
       printer = MiniTest::Mock.new

--- a/spec/integration/chunker_spec.rb
+++ b/spec/integration/chunker_spec.rb
@@ -19,14 +19,17 @@ describe Lhm::Chunker do
 
     it 'should copy 1  rows from origin to destination even if the id of the single row does not start at 1' do
       execute("insert into origin set id = 1001 ")
+      printer = Lhm::Printer::Base.new
 
-      Lhm::Chunker.new(@migration, connection, {}).run
+      def printer.notify(*) ;end
+      def printer.end(*) [] ;end
+
+      Lhm::Chunker.new(@migration, connection, {:throttler => Lhm::Throttler::Time.new(:stride => 100), :printer => printer} ).run
 
       slave do
         count_all(@destination.name).must_equal(1)
       end
 
-      printer.verify
     end
 
     it 'should copy 23 rows from origin to destination' do


### PR DESCRIPTION
## Problem

This is actually a big deal, it seems it is possible to destroy data for a table with a single row when the single's row id is not `1`.

It seems connected to this patch https://github.com/soundcloud/lhm/pull/39/files#diff-5f043f4ad9ef9057e658146216f47dbfR28.

## Solution

We'll follow up with a patch ASAP, for now I want a sanity check, Am I not seeing something that would prevent this piece of code:

```ruby
 def execute
      return unless @start && @limit
      @next_to_insert = @start
      while @next_to_insert < @limit || (@next_to_insert == 1 && @start == 1)
        stride = @throttler.stride
        affected_rows = @connection.update(copy(bottom, top(stride)))

        if @throttler && affected_rows > 0
          @throttler.run
        end
```

from skipping a single row if that rows id were say `1001` ?

@jasonhl @sroysen @singerwang @oliverf @arthurnn  @erikogan  @pellegrino @durran 