### PR TITLE
In Which We Allow Migrations to Run at Lower Isolation Levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,24 @@ Lhm.change_table :users, :atomic_switch => true do |m|
 end
 ```
 
+## Isolation levels
+
+Lhm issues a series of INSERT INTO... SELECT statements over the course of the migration
+against the table being migrated. At the repeatable read and above isolation levels,
+MySQL aquires a lock on the table being SELECT'ed from.  If the table you are migrating
+is write heavy or particularly large, you may see deadlocks on writes into the
+table being migrated.  These may be avoided by running the INSERT INTO... SELECT statements
+at the READ COMMITTED isolation level.
+
+If during the migration you notice a large number of deadlocks against the table
+being migrated, you can avoid them by running the migration at a lower isolation level:
+
+```ruby
+Lhm.change_table :users, :lower_isolation_level => true do |m|
+  # ...
+end
+```
+
 ## Limiting the data that is migrated
 
 For instances where you want to limit the data that is migrated to the new

--- a/lib/lhm/invoker.rb
+++ b/lib/lhm/invoker.rb
@@ -37,9 +37,16 @@ module Lhm
       end
     end
 
+    def set_session_isolation_level(options)
+      if options[:lower_isolation_level]
+        @connection.execute('SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED')
+      end
+    end
+
     def run(options = {})
       normalize_options(options)
       set_session_lock_wait_timeouts
+      set_session_isolation_level(options)
       migration = @migrator.run
 
       Entangler.new(migration, @connection).run do

--- a/spec/unit/invoker_spec.rb
+++ b/spec/unit/invoker_spec.rb
@@ -1,0 +1,31 @@
+# Copyright (c) 2011 - 2013, SoundCloud Ltd., Rany Keddo, Tobias Bielohlawek, Tobias
+# Schmidt
+
+require File.expand_path(File.dirname(__FILE__)) + '/unit_helper'
+
+require 'lhm/invoker'
+
+describe Lhm::Invoker do
+  include UnitHelper
+
+  before(:each) do
+    @origin = MiniTest::Mock.new
+    @origin.expect(:destination_name, 1)
+    @connection = MiniTest::Mock.new
+
+    @invoker = Lhm::Invoker.new(@origin, @connection)
+  end
+
+  it 'should lower isolation level when asked' do
+    @connection.expect(:execute, 1) do |stmt|
+      expected = 'SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED'
+      stmt == expected || stmt == [expected]
+    end
+    @invoker.set_session_isolation_level(lower_isolation_level: true)
+    @connection.verify
+  end
+
+  it 'leaves isolation levels alone by default' do
+    @invoker.set_session_isolation_level({})
+  end
+end


### PR DESCRIPTION
We tried to do an LHM migration agains a large table with frequent writes the other day, and a flurry of deadlocks started appearing for writers to the table.  According to the MySQL docs:

```
INSERT INTO T SELECT ... FROM S WHERE ... sets an exclusive index record lock (without a gap lock) 
on each row inserted into T. If the transaction isolation level is READ COMMITTED, or 
innodb_locks_unsafe_for_binlog is enabled and the transaction isolation level is not SERIALIZABLE, 
InnoDB does the search on S as a consistent read (no locks). Otherwise, InnoDB sets shared next-key 
locks on rows from S. InnoDB has to set locks in the latter case: In roll-forward recovery from a backup, 
every SQL statement must be executed in exactly the same way it was done originally.
```

Which indicates we should be able to avoid deadlocks by lowering the transaction isolation level for those `INSERT INTO SELECT` statements coming from the migration.