### PR TITLE
Improve readability of cleanup method calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,19 +196,19 @@ Lhm.cleanup
 
 To remove any Lhm tables/triggers found:
 ```ruby
-Lhm.cleanup(true)
+Lhm.cleanup(:run)
 ```
 
 Optionally only remove tables up to a specific Time, if you want to retain previous migrations.
 
 Rails:
 ```ruby
-Lhm.cleanup(true, until: 1.day.ago)
+Lhm.cleanup(:run, until: 1.day.ago)
 ```
 
 Ruby:
 ```ruby
-Lhm.cleanup(true, until: Time.now - 86400)
+Lhm.cleanup(:run, until: Time.now - 86400)
 ```
 
 ## Contributing

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -83,7 +83,7 @@ module Lhm
     else
       puts "Existing LHM backup tables: #{lhm_tables.join(', ')}."
       puts "Existing LHM triggers: #{lhm_triggers.join(', ')}."
-      puts 'Run Lhm.cleanup(true) to drop them all.'
+      puts 'Run Lhm.cleanup(:run) to drop them all.'
       false
     end
   end

--- a/spec/integration/cleanup_spec.rb
+++ b/spec/integration/cleanup_spec.rb
@@ -19,7 +19,7 @@ describe Lhm, 'cleanup' do
     end
 
     after(:each) do
-      Lhm.cleanup(true)
+      Lhm.cleanup(:run)
     end
 
     it 'should show temporary tables' do
@@ -65,7 +65,7 @@ describe Lhm, 'cleanup' do
     end
 
     it 'should delete temporary tables' do
-      Lhm.cleanup(true).must_equal(true)
+      Lhm.cleanup(:run).must_equal(true)
       Lhm.cleanup.must_equal(true)
     end
   end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -28,7 +28,7 @@ module IntegrationHelper
     adapter = ar_conn port
     Lhm.setup(adapter)
     unless defined?(@@cleaned_up)
-      Lhm.cleanup(true)
+      Lhm.cleanup(:run)
       @@cleaned_up  = true
     end
     @connection = adapter

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -6,7 +6,7 @@ require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
 describe Lhm do
   include IntegrationHelper
 
-  before(:each) { connect_master!; Lhm.cleanup(true) }
+  before(:each) { connect_master!; Lhm.cleanup(:run) }
 
   describe 'id column requirement' do
     it 'should migrate the table when id is pk' do


### PR DESCRIPTION
This is a minor change to improve the clarity of the documentation. `cleanup(:run)` is more self-explanatory than `cleanup(true)`.