### PR TITLE
Fix a minor typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ ActiveRecord 3.2.x and 4.x (mysql and mysql2 adapters).
 
 ## Limitations
 
-Due to the Chunker implementation, Lhm requires that the table to migrate has a
+Due to the Chunker implementation, Lhm requires that the table to migrate has
 a single integer numeric key column called `id`.
 
 Another note about the Chunker, it performs static sized row copies against the `id`


### PR DESCRIPTION
Remove extra `a`