### PR TITLE
Update Throttler options documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # 3.0.0
 
-* Drop support for throttle and stride options. Use `throttler`, instead:
+* Drop support for `throttle` and `stride` options. Use `throttler`, instead:
 ```
-Lhm.change_table :users, throttler: [:time_throttler, {stride: x}] do
+Lhm.change_table :users, throttler: :time_throttler do
 end
 ```
 * #118 - Truncate long trigger names. (@sj26)

--- a/lib/lhm.rb
+++ b/lib/lhm.rb
@@ -27,10 +27,8 @@ module Lhm
   #
   # @param [String, Symbol] table_name Name of the table
   # @param [Hash] options Optional options to alter the chunk / switch behavior
-  # @option options [Fixnum] :stride
-  #   Size of a chunk (defaults to: 40,000)
-  # @option options [Fixnum] :throttle
-  #   Time to wait between chunks in milliseconds (defaults to: 100)
+  # @option options [Lhm::Command, String, Symbol, Class] :throttler
+  #   Type of Throttler to use (defaults to: `:time_throttler`)
   # @option options [Fixnum] :start
   #   Primary Key position at which to start copying chunks
   # @option options [Fixnum] :limit

--- a/spec/integration/lhm_spec.rb
+++ b/spec/integration/lhm_spec.rb
@@ -318,7 +318,7 @@ describe Lhm do
         end
         sleep 2
 
-        options = { :stride => 10, :throttle => 97, :atomic_switch => false }
+        options = { :atomic_switch => false }
         Lhm.change_table(:users, options) do |t|
           t.add_column(:parallel, "INT(10) DEFAULT '0'")
         end
@@ -341,7 +341,7 @@ describe Lhm do
         end
         sleep 2
 
-        options = { :stride => 10, :throttle => 97, :atomic_switch => false }
+        options = { :atomic_switch => false }
         Lhm.change_table(:users, options) do |t|
           t.add_column(:parallel, "INT(10) DEFAULT '0'")
         end


### PR DESCRIPTION
Fixes some inconsistencies and outdated documentation around the `throttler`, `stride`, and `throttle` options.
