### PR TITLE
Add time_stamp and limit table name to 64 characters

### DIFF
--- a/lib/lhm/table.rb
+++ b/lib/lhm/table.rb
@@ -21,7 +21,8 @@ module Lhm
     end
 
     def destination_name
-      "lhmn_#{ @name }"
+      time_stamp = Time.now.strftime "%Y_%m_%d_%H_%M_%S_#{ '%03d' % (@start.usec / 1000) }"
+      "lhmn_#{ time_stamp }_#{ @name }"[0...64]
     end
 
     def self.parse(table_name, connection)


### PR DESCRIPTION
LHM migration fails when there is existing lhm temp table (for example: "lhmn_users" which got created by previous LHM migration).
We need to do Lhm.cleanup to clean those tables.
Instead, if we have time-stamp, it wont conflict with the previous temp table.

Please review.