### PR TITLE
Moved to date_sources_exist from table_exists

### DIFF
--- a/lib/lhm/atomic_switcher.rb
+++ b/lib/lhm/atomic_switcher.rb
@@ -41,8 +41,8 @@ module Lhm
     end
 
     def validate
-      unless @connection.table_exists?(@origin.name) &&
-             @connection.table_exists?(@destination.name)
+      unless @connection.data_source_exists?(@origin.name) &&
+             @connection.data_source_exists?(@destination.name)
         error "`#{ @origin.name }` and `#{ @destination.name }` must exist"
       end
     end

--- a/lib/lhm/entangler.rb
+++ b/lib/lhm/entangler.rb
@@ -68,11 +68,11 @@ module Lhm
     end
 
     def validate
-      unless @connection.table_exists?(@origin.name)
+      unless @connection.data_source_exists?(@origin.name)
         error("#{ @origin.name } does not exist")
       end
 
-      unless @connection.table_exists?(@destination.name)
+      unless @connection.data_source_exists?(@destination.name)
         error("#{ @destination.name } does not exist")
       end
     end

--- a/lib/lhm/locked_switcher.rb
+++ b/lib/lhm/locked_switcher.rb
@@ -53,8 +53,8 @@ module Lhm
     end
 
     def validate
-      unless @connection.table_exists?(@origin.name) &&
-             @connection.table_exists?(@destination.name)
+      unless @connection.data_source_exists?(@origin.name) &&
+             @connection.data_source_exists?(@destination.name)
         error "`#{ @origin.name }` and `#{ @destination.name }` must exist"
       end
     end

--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -183,7 +183,7 @@ module Lhm
     private
 
     def validate
-      unless @connection.table_exists?(@origin.name)
+      unless @connection.data_source_exists?(@origin.name)
         error("could not find origin table #{ @origin.name }")
       end
 
@@ -193,7 +193,7 @@ module Lhm
 
       dest = @origin.destination_name
 
-      if @connection.table_exists?(dest)
+      if @connection.data_source_exists?(dest)
         error("#{ dest } should not exist; not cleaned up from previous run?")
       end
     end

--- a/spec/integration/atomic_switcher_spec.rb
+++ b/spec/integration/atomic_switcher_spec.rb
@@ -90,7 +90,7 @@ describe Lhm::AtomicSwitcher do
       switcher.run
 
       slave do
-        table_exists?(@origin).must_equal true
+        data_source_exists?(@origin).must_equal true
         table_read(@migration.archive_name).columns.keys.must_include 'origin'
       end
     end
@@ -100,7 +100,7 @@ describe Lhm::AtomicSwitcher do
       switcher.run
 
       slave do
-        table_exists?(@destination).must_equal false
+        data_source_exists?(@destination).must_equal false
         table_read(@origin.name).columns.keys.must_include 'destination'
       end
     end

--- a/spec/integration/integration_helper.rb
+++ b/spec/integration/integration_helper.rb
@@ -121,8 +121,8 @@ module IntegrationHelper
     Lhm::Table.parse(fixture_name, @connection)
   end
 
-  def table_exists?(table)
-    connection.table_exists?(table.name)
+  def data_source_exists?(table)
+    connection.data_source_exists?(table.name)
   end
 
   #

--- a/spec/integration/locked_switcher_spec.rb
+++ b/spec/integration/locked_switcher_spec.rb
@@ -32,7 +32,7 @@ describe Lhm::LockedSwitcher do
       switcher.run
 
       slave do
-        table_exists?(@origin).must_equal true
+        data_source_exists?(@origin).must_equal true
         table_read(@migration.archive_name).columns.keys.must_include 'origin'
       end
     end
@@ -42,7 +42,7 @@ describe Lhm::LockedSwitcher do
       switcher.run
 
       slave do
-        table_exists?(@destination).must_equal false
+        data_source_exists?(@destination).must_equal false
         table_read(@origin.name).columns.keys.must_include 'destination'
       end
     end


### PR DESCRIPTION
As of this change in Rails (https://github.com/rails/rails/pull/21601) the #table_exists? should be replaced by #data_source_exists?

There was already an open issue for this matter: https://github.com/soundcloud/lhm/issues/144