### PR TITLE
Abort migration if a given table refer by other tables using foreign key constraints

### DIFF
--- a/lib/lhm/migrator.rb
+++ b/lib/lhm/migrator.rb
@@ -187,6 +187,11 @@ module Lhm
         error("could not find origin table #{ @origin.name }")
       end
 
+      unless @origin.satisfies_references_column_requirement?
+        tables = @origin.references.map{|a| "#{a['table_name']}:#{a['constraint_name']}"}.join(', ')
+        error("foreign key constraint fails for tables (#{tables}); before running LHM migration you need to drop this foreign keys;")
+      end
+
       unless @origin.satisfies_id_column_requirement?
         error('origin does not satisfy `id` key requirements')
       end

--- a/spec/fixtures/fk_child_table.ddl
+++ b/spec/fixtures/fk_child_table.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `fk_child_table` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `origin_table_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`),
+  CONSTRAINT `fk_origin_table_id` FOREIGN KEY (`origin_table_id`) REFERENCES `origin_example` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/fixtures/origin_example.ddl
+++ b/spec/fixtures/origin_example.ddl
@@ -1,0 +1,6 @@
+CREATE TABLE `origin_example` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `user_id` int(11) NOT NULL,
+  `master_id` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8

--- a/spec/integration/references_spec.rb
+++ b/spec/integration/references_spec.rb
@@ -1,0 +1,65 @@
+# Copyright (c) 2011 - 2013, SoundCloud Ltd., Rany Keddo, Tobias Bielohlawek, Tobias
+# Schmidt
+
+require File.expand_path(File.dirname(__FILE__)) + '/integration_helper'
+
+require 'lhm'
+
+describe Lhm do
+  include IntegrationHelper
+
+
+    describe 'the simplest case' do
+      before(:each) do
+        connect_master!
+        Lhm.cleanup(true)
+        %w(fk_child_table origin_example).each do |table|
+          execute "drop table if exists #{table}"
+        end
+        %w(origin_example fk_child_table).each do |table|
+          execute "drop table if exists `fk_child_table`"
+          table_create(table)
+      end
+    end
+
+    after(:each) do
+      Lhm.cleanup(true)
+    end
+
+    it 'should show the foreign key constraints for given table' do
+      actual = table_read(:origin_example).references
+      expected = [{
+        "constraint_name"=> "fk_origin_table_id",
+        "table_name"=> "fk_child_table",
+        "table_schema"=> "lhm",
+        "column_name"=> "origin_table_id"
+        }]
+      actual.must_equal(expected)
+    end
+
+    it 'should raise an exception for foreign key constraint fails for referencing tables' do
+      exception = assert_raises(Exception) {
+        Lhm.change_table(:origin_example) do |t|
+          t.add_column(:new_column, "INT(12) DEFAULT '0'")
+        end
+      }
+      references = table_read(:origin_example).references
+      tables = references.map{|a| "#{a['table_name']}:#{a['constraint_name']}"}.join(', ')
+      message = "foreign key constraint fails for tables (#{tables}); before running LHM migration you need to drop this foreign keys;"
+      assert_equal(message, exception.message )
+    end
+
+    it 'should add a column after droping foreign key constraints' do
+      execute "alter table `fk_child_table` drop foreign key `fk_origin_table_id`"
+      Lhm.change_table(:origin_example) do |t|
+        t.add_column(:new_column, "INT(12) DEFAULT '0'")
+      end
+      connect_master!
+      table_read(:origin_example).columns['new_column'].must_equal({
+        :type => 'int(12)',
+        :is_nullable => 'YES',
+        :column_default => '0',
+      })
+    end
+  end
+end

--- a/spec/unit/table_spec.rb
+++ b/spec/unit/table_spec.rb
@@ -20,6 +20,11 @@ describe Lhm::Table do
       table.instance_variable_set('@columns', columns)
     end
 
+    def set_references(table, references)
+      table.instance_variable_set('@references', references)
+    end
+
+
     it 'should be satisfied with a single column primary key called id' do
       @table = Lhm::Table.new('table', 'id')
       set_columns(@table, { 'id' => { :type => 'int(1)' } })
@@ -37,5 +42,18 @@ describe Lhm::Table do
       set_columns(@table, { 'id' => { :type => 'varchar(255)' } })
       @table.satisfies_id_column_requirement?.must_equal false
     end
+
+    it 'should be satisfied if origin table not refer by any other table using foreign key' do
+      @table = Lhm::Table.new('table')
+      set_references(@table, [])
+      @table.satisfies_references_column_requirement?.must_equal true
+    end
+
+    it 'should NOT be satisfied if origin table refer by any other table using foreign key' do
+      @table = Lhm::Table.new('table', 'id')
+      set_references(@table, [{"CONSTRAINT_NAME"=>"fk_rails_40ebb3948d", "TABLE_NAME"=>"child_table", "TABLE_SCHEMA"=>"schema", "COLUMN_NAME"=>"table_id"}])
+      @table.satisfies_references_column_requirement?.must_equal false
+    end
+
   end
 end


### PR DESCRIPTION
The original problem in issue #141  was that if we alter table having external constraints (i.e refer by other tables using foreign key constraints) using lhm. it modifies the table without any warning and errors and lhm uses a method of modification is copy table and rename strategy when lhm renames origin table that time all references get changed. In MySQL renaming of tables works like it changes all external references to a new_table so it causing an issue after migration runs. I have faced this issue as well

So in this pull request have just added validation it checks external foreign key constraints for given table and if it founds any table having references so it aborts the migration. have to add this validation until the time LHM/we provide any solution for rebuilding for foreign key constraints 