### PR TITLE
Fix Lhm.cleanup command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,20 +196,23 @@ Lhm.cleanup
 ```
 
 To remove any Lhm tables/triggers found:
+
 ```ruby
-Lhm.cleanup(:run)
+Lhm.cleanup(true)
 ```
 
 Optionally only remove tables up to a specific Time, if you want to retain previous migrations.
 
 Rails:
+
 ```ruby
-Lhm.cleanup(:run, until: 1.day.ago)
+Lhm.cleanup(true, until: 1.day.ago)
 ```
 
 Ruby:
+
 ```ruby
-Lhm.cleanup(:run, until: Time.now - 86400)
+Lhm.cleanup(true, until: Time.now - 86400)
 ```
 
 ## Contributing


### PR DESCRIPTION
## Issue
While running the `Lhm.cleanup` command, I realized that the instructions and examples in the README stated the first argument as `:run` (see below) instead of a boolean as reflected in the [source code](https://github.com/darellkoh/lhm/blob/50907121eee514649fa944fb300d5d8a64fa873e/lib/lhm.rb#L59).

```ruby
Lhm.cleanup(:run)
```

## Fix
I modified the first argument in the `Lhm.cleanup` README.md instructions and examples to reflect the intended boolean usage in the source code:

```ruby
Lhm.cleanup(true)
```

Rails
```ruby
Lhm.cleanup(true, until: 1.day.ago)
```

