### PR TITLE
chore: configure Renovate [skip ci] (auto)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>soundcloud/renovate-presets//ruby/default"
+  ]
+}


### PR DESCRIPTION

This is an onboarding PR to help you configure settings before regular Pull Requests begin.

For further information on onboarding check out [the docs on echo](https://echo.soundcloud.org/docs/default/component/renovate/onboarding/).
Runtime specific renovate presets are available in our [renovate-presets](https://github.com/soundcloud/renovate-presets) repo.
To enable one of them, update the "extends" config in this PR to reference the runtime.
This PR enables the default preset.

To activate Renovate, merge this Pull Request. To disable Renovate, simply close this Pull Request unmerged.

Work towards DX-432.
